### PR TITLE
Persist finalized session data in blob manifests

### DIFF
--- a/app/api/finalize-session/route.ts
+++ b/app/api/finalize-session/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { list } from '@vercel/blob'
 import { putBlobFromBuffer } from '@/lib/blob'
 import { sendSummaryEmail } from '@/lib/email'
+import { getSession } from '@/lib/data'
 import { z } from 'zod'
 
 type TurnSummary = {
@@ -9,8 +10,10 @@ type TurnSummary = {
   audio: string | null
   manifest: string
   transcript: string
+  assistantReply: string
   durationMs: number
   createdAt: string | null
+  provider?: string
 }
 
 const schema = z.object({
@@ -23,46 +26,147 @@ export async function POST(req: NextRequest) {
     const body = await req.json()
     const { sessionId, email } = schema.parse(body)
 
-    const prefix = `sessions/${sessionId}/`
-    const { blobs } = await list({ prefix, limit: 2000 })
-    const turnBlobs = blobs
-      .filter((b) => /turn-\d+\.json$/.test(b.pathname))
-      .sort((a, b) => a.pathname.localeCompare(b.pathname))
+    const token = process.env.VERCEL_BLOB_READ_WRITE_TOKEN
+    let turnBlobs: Awaited<ReturnType<typeof list>>['blobs'] = []
+    if (token) {
+      try {
+        const prefix = `sessions/${sessionId}/`
+        const listed = await list({ prefix, limit: 2000, token })
+        turnBlobs = listed.blobs.filter((b) => /turn-\d+\.json$/.test(b.pathname))
+        turnBlobs.sort((a, b) => a.pathname.localeCompare(b.pathname))
+      } catch (err) {
+        console.warn('Failed to list blob turns', err)
+      }
+    }
 
     const turns: TurnSummary[] = []
     let totalDuration = 0
     let startedAt: string | null = null
     let endedAt: string | null = null
 
-    for (const blob of turnBlobs) {
-      try {
-        const resp = await fetch(blob.url)
-        const json = await resp.json()
-        const turnNumber = Number(json.turn) || 0
-        const transcript = typeof json.transcript === 'string' ? json.transcript : ''
-        const created = json.createdAt || blob.uploadedAt || null
-        if (created) {
-          if (!startedAt || created < startedAt) startedAt = created
-          if (!endedAt || created > endedAt) endedAt = created
+    if (turnBlobs.length) {
+      for (const blob of turnBlobs) {
+        try {
+          const resp = await fetch(blob.downloadUrl || blob.url)
+          const json = await resp.json()
+          const turnNumber = Number(json.turn) || 0
+          const transcript = typeof json.transcript === 'string' ? json.transcript : ''
+          const assistantReply = typeof json.assistantReply === 'string' ? json.assistantReply : ''
+          const createdRaw = json.createdAt || blob.uploadedAt || null
+          const created =
+            typeof createdRaw === 'string'
+              ? createdRaw
+              : createdRaw instanceof Date
+              ? createdRaw.toISOString()
+              : null
+          if (created) {
+            if (!startedAt || created < startedAt) startedAt = created
+            if (!endedAt || created > endedAt) endedAt = created
+          }
+          const duration = Number(json.durationMs) || 0
+          totalDuration += duration
+          turns.push({
+            turn: turnNumber,
+            audio: json.userAudioUrl || null,
+            manifest: blob.downloadUrl || blob.url,
+            transcript,
+            assistantReply,
+            durationMs: duration,
+            createdAt: created,
+            provider: typeof json.provider === 'string' ? json.provider : undefined,
+          })
+        } catch (err) {
+          console.warn('Failed to parse turn manifest', err)
+          // Skip malformed turn entries but continue processing others
         }
-        const duration = Number(json.durationMs) || 0
-        totalDuration += duration
-        turns.push({
-          turn: turnNumber,
-          audio: json.userAudioUrl || null,
-          manifest: blob.url,
-          transcript: transcript.slice(0, 160),
-          durationMs: duration,
-          createdAt: created,
-        })
-      } catch {
-        // Skip malformed turn entries but continue processing others
       }
     }
 
+    if (!turns.length) {
+      const inMemory = await getSession(sessionId)
+      if (inMemory?.turns?.length) {
+        let currentTurn = 0
+        for (const entry of inMemory.turns) {
+          if (entry.role === 'user') {
+            currentTurn += 1
+            turns.push({
+              turn: currentTurn,
+              audio: entry.audio_blob_url || null,
+              manifest: '',
+              transcript: entry.text,
+              assistantReply: '',
+              durationMs: 0,
+              createdAt: inMemory.created_at,
+            })
+          } else if (entry.role === 'assistant') {
+            const target = turns.find((t) => t.turn === currentTurn)
+            if (target) {
+              target.assistantReply = entry.text
+            } else {
+              turns.push({
+                turn: currentTurn,
+                audio: null,
+                manifest: '',
+                transcript: '',
+                assistantReply: entry.text,
+                durationMs: 0,
+                createdAt: inMemory.created_at,
+              })
+            }
+          }
+        }
+        totalDuration = inMemory.duration_ms || 0
+        startedAt = inMemory.created_at
+        endedAt = inMemory.created_at
+      }
+    }
+
+    turns.sort((a, b) => a.turn - b.turn)
+
+    const conversationLines: { role: 'user' | 'assistant'; text: string; turn: number; audio?: string | null }[] = []
+    for (const entry of turns) {
+      if (entry.transcript) {
+        conversationLines.push({ role: 'user', text: entry.transcript, turn: entry.turn, audio: entry.audio })
+      }
+      if (entry.assistantReply) {
+        conversationLines.push({ role: 'assistant', text: entry.assistantReply, turn: entry.turn })
+      }
+    }
+
+    const transcriptText = conversationLines
+      .filter((line) => line.text)
+      .map((line) => `${line.role === 'user' ? 'User' : 'Assistant'} (turn ${line.turn}): ${line.text}`)
+      .join('\n')
+
+    const transcriptJson = {
+      sessionId,
+      createdAt: startedAt,
+      turns: conversationLines.map((line) => ({
+        role: line.role,
+        turn: line.turn,
+        text: line.text,
+        audio: line.audio || null,
+      })),
+    }
+
+    const transcriptTxtUrl = (
+      await putBlobFromBuffer(
+        `sessions/${sessionId}/transcript-${sessionId}.txt`,
+        Buffer.from(transcriptText, 'utf8'),
+        'text/plain; charset=utf-8'
+      )
+    ).url
+    const transcriptJsonUrl = (
+      await putBlobFromBuffer(
+        `sessions/${sessionId}/transcript-${sessionId}.json`,
+        Buffer.from(JSON.stringify(transcriptJson, null, 2), 'utf8'),
+        'application/json'
+      )
+    ).url
+
     const manifest = {
       sessionId,
-      email: email || null,
+      email: email || process.env.DEFAULT_NOTIFY_EMAIL || null,
       startedAt,
       endedAt,
       totals: { turns: turns.length, durationMs: totalDuration },
@@ -71,9 +175,15 @@ export async function POST(req: NextRequest) {
         audio: t.audio,
         manifest: t.manifest,
         transcript: t.transcript,
+        assistantReply: t.assistantReply,
         durationMs: t.durationMs,
         createdAt: t.createdAt,
+        provider: t.provider,
       })),
+      artifacts: {
+        transcript_txt: transcriptTxtUrl,
+        transcript_json: transcriptJsonUrl,
+      },
     }
 
     const manifestUrl = (
@@ -87,17 +197,28 @@ export async function POST(req: NextRequest) {
     let emailStatus: Awaited<ReturnType<typeof sendSummaryEmail>> | { skipped: true }
     emailStatus = { skipped: true }
 
-    if (email) {
+    const targetEmail = email || process.env.DEFAULT_NOTIFY_EMAIL
+    if (targetEmail) {
       const lines = turns
-        .map((t) => `Turn ${t.turn}: ${t.transcript || '[no transcript]'}\nAudio: ${t.audio || 'unavailable'}\nManifest: ${t.manifest}`)
+        .map(
+          (t) =>
+            `Turn ${t.turn}: ${t.transcript || '[no transcript]'}\nAssistant: ${t.assistantReply || '[no reply]'}\nAudio: ${
+              t.audio || 'unavailable'
+            }\nManifest: ${t.manifest || 'unavailable'}`
+        )
         .join('\n\n')
-      const bodyParts = ['Your session is finalized. Here are your links.', `Session manifest: ${manifestUrl}`]
+      const bodyParts = [
+        'Your session is finalized. Here are your links.',
+        `Session manifest: ${manifestUrl}`,
+        `Transcript (txt): ${transcriptTxtUrl}`,
+        `Transcript (json): ${transcriptJsonUrl}`,
+      ]
       if (lines) {
         bodyParts.push('', lines)
       }
       const bodyText = bodyParts.filter((part) => typeof part === 'string' && part.length).join('\n')
       try {
-        emailStatus = await sendSummaryEmail(email, "Dad's Interview Bot - Session Summary", bodyText)
+        emailStatus = await sendSummaryEmail(targetEmail, "Dad's Interview Bot - Session Summary", bodyText)
       } catch (e: any) {
         emailStatus = { ok: false, provider: 'unknown', error: e?.message || 'send_failed' }
       }
@@ -108,6 +229,7 @@ export async function POST(req: NextRequest) {
       manifestUrl,
       totalTurns: turns.length,
       totalDurationMs: totalDuration,
+      artifacts: { transcript_txt: transcriptTxtUrl, transcript_json: transcriptJsonUrl },
       emailStatus,
     })
   } catch (e: any) {

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -6,7 +6,10 @@ export async function GET() {
   const rows = items.map(s => ({
     id: s.id, created_at: s.created_at, title: s.title || null,
     status: s.status, total_turns: s.total_turns,
-    artifacts: { transcript_txt: Boolean(s.artifacts?.transcript_txt), transcript_json: Boolean(s.artifacts?.transcript_json) }
+    artifacts: {
+      transcript_txt: typeof s.artifacts?.transcript_txt === 'string' ? s.artifacts?.transcript_txt : null,
+      transcript_json: typeof s.artifacts?.transcript_json === 'string' ? s.artifacts?.transcript_json : null,
+    }
   }))
   // DEMO: merge client-stored demoHistory (if any) as minimal entries
   let demo: any[] = []
@@ -14,6 +17,13 @@ export async function GET() {
     const raw = (globalThis as any)?.localStorage?.getItem?.('demoHistory')
     if (raw) demo = JSON.parse(raw)
   } catch {}
-  const demoRows = (demo||[]).map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{ transcript_txt:false, transcript_json:false } }))
+  const demoRows = (demo||[]).map(d => ({
+    id: d.id,
+    created_at: d.created_at,
+    title: 'Demo session',
+    status: 'completed',
+    total_turns: 1,
+    artifacts: { transcript_txt: null, transcript_json: null },
+  }))
   return NextResponse.json({ items: [...demoRows, ...rows] })
 }

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,7 +1,14 @@
 "use client"
 import { useEffect, useState } from 'react'
 
-type Row = { id: string, created_at: string, title: string|null, status: string, total_turns: number, artifacts: { transcript_txt: boolean, transcript_json: boolean } }
+type Row = {
+  id: string
+  created_at: string
+  title: string | null
+  status: string
+  total_turns: number
+  artifacts: { transcript_txt: string | null; transcript_json: string | null }
+}
 
 export default function HistoryPage() {
   const [rows, setRows] = useState<Row[]>([])
@@ -16,7 +23,14 @@ export default function HistoryPage() {
           const raw = localStorage.getItem('demoHistory')
           if (raw) {
             const list = JSON.parse(raw) as { id:string, created_at:string }[]
-            demoRows = list.map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{ transcript_txt:false, transcript_json:false } }))
+            demoRows = list.map(d => ({
+              id: d.id,
+              created_at: d.created_at,
+              title: 'Demo session',
+              status: 'completed',
+              total_turns: 1,
+              artifacts: { transcript_txt: null, transcript_json: null },
+            }))
           }
         } catch {}
         setRows([...(demoRows||[]), ...(serverRows||[])])
@@ -41,8 +55,16 @@ export default function HistoryPage() {
               </div>
               <div className="space-x-2 text-sm">
                 <a className="underline" href={`/session/${s.id}`}>Open</a>
-                {s.artifacts?.transcript_txt && <a className="underline" href="#">Transcript (txt)</a>}
-                {s.artifacts?.transcript_json && <a className="underline" href="#">Transcript (json)</a>}
+                {s.artifacts?.transcript_txt && (
+                  <a className="underline" href={s.artifacts.transcript_txt} target="_blank" rel="noreferrer">
+                    Transcript (txt)
+                  </a>
+                )}
+                {s.artifacts?.transcript_json && (
+                  <a className="underline" href={s.artifacts.transcript_json} target="_blank" rel="noreferrer">
+                    Transcript (json)
+                  </a>
+                )}
               </div>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- update the finalize-session API to pull turn manifests from Blob storage (with in-memory fallback), build full transcripts, upload session artifacts, and default to the configured notification email
- teach the shared data layer to hydrate sessions from stored manifests so history/session views survive stateless environments
- return real transcript URLs from the history API and surface them in the history page UI

## Testing
- `npx vitest run --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_68c9b57001e4832a80962a734ae23adc