### PR TITLE
Handle stateless finalize fallback

### DIFF
--- a/ToDoLater.txt
+++ b/ToDoLater.txt
@@ -13,10 +13,7 @@ Add E2E tests for first-turn flow, finalize, and history listing
 Integrate OpenAI Realtime Voice (WS client, server token endpoint, TTS backoff)
 Add interactive voice barge-in, VAD, and interruptible TTS playback
 Offer selectable providers (OpenAI/Google) for STT+LLM, runtime switch in UI
-<<<<<<< ours
 Document interview flow expectations inside the product and keep [`docs/interview-guide.md`](docs/interview-guide.md) handy when training the agent.
-=======
 
 - [ ] Prototype the OpenAI Neural/NeuralHD TTS integration using the helper in `lib/openaiTts.ts`, then replace the browser SpeechSynthesis fallback once streaming playback + latency checks look good.
 - [ ] Add a UI toggle that lets users choose between native browser TTS and OpenAI voices (remember offline fallback + quota exhaustion case).
->>>>>>> theirs

--- a/app/api/blob/[...path]/route.ts
+++ b/app/api/blob/[...path]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getFallbackBlob } from '@/lib/blob'
+
+function notFound() {
+  return new NextResponse('Not found', { status: 404 })
+}
+
+function buildFilename(segments: string[]): string {
+  const raw = segments[segments.length - 1] || 'download'
+  const sanitized = raw.replace(/[^a-zA-Z0-9._-]/g, '_')
+  return sanitized || 'download'
+}
+
+function createResponse(
+  paramsPath: string[] | undefined,
+  includeBody: boolean,
+  download: boolean,
+) {
+  const segments = Array.isArray(paramsPath) ? paramsPath : []
+  if (!segments.length) return notFound()
+  const key = segments.join('/')
+  const record = getFallbackBlob(key)
+  if (!record) return notFound()
+
+  const headers = new Headers()
+  headers.set('Content-Type', record.contentType)
+  headers.set('Cache-Control', 'no-store')
+  headers.set('Content-Length', String(record.buffer.byteLength))
+
+  const filename = buildFilename(segments)
+  const disposition = download ? 'attachment' : 'inline'
+  headers.set('Content-Disposition', `${disposition}; filename="${filename}"`)
+
+  const body = includeBody ? record.buffer : null
+  return new NextResponse(body, { status: 200, headers })
+}
+
+export async function GET(req: NextRequest, ctx: { params: { path: string[] } }) {
+  const download = req.nextUrl.searchParams.has('download')
+  return createResponse(ctx.params.path, true, download)
+}
+
+export async function HEAD(req: NextRequest, ctx: { params: { path: string[] } }) {
+  const download = req.nextUrl.searchParams.has('download')
+  return createResponse(ctx.params.path, false, download)
+}

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -11,11 +11,14 @@ export async function GET() {
     status: s.status,
     total_turns: s.total_turns,
     artifacts: {
-      transcript_txt: Boolean(s.artifacts?.transcript_txt),
-      transcript_json: Boolean(s.artifacts?.transcript_json),
+      transcript_txt: s.artifacts?.transcript_txt || null,
+      transcript_json: s.artifacts?.transcript_json || null,
+      session_manifest: s.artifacts?.session_manifest || s.artifacts?.manifest || null,
+      session_audio: s.artifacts?.session_audio || null,
     },
-    manifestUrl: s.artifacts?.manifest || null,
+    manifestUrl: s.artifacts?.session_manifest || s.artifacts?.manifest || null,
     firstAudioUrl: s.turns?.find(t => t.audio_blob_url)?.audio_blob_url || null,
+    sessionAudioUrl: s.artifacts?.session_audio || null,
   }))
 
   const { items: stored } = await fetchStoredSessions({ limit: 50 })
@@ -27,9 +30,16 @@ export async function GET() {
       title: null,
       status: 'completed',
       total_turns: session.totalTurns,
-      artifacts: { transcript_txt: false, transcript_json: Boolean(session.manifestUrl) },
-      manifestUrl: session.manifestUrl,
+      artifacts: {
+        transcript_txt: session.artifacts?.transcript_txt || null,
+        transcript_json: session.artifacts?.transcript_json || null,
+        session_manifest: session.artifacts?.session_manifest || session.artifacts?.manifest || session.manifestUrl || null,
+        session_audio: session.artifacts?.session_audio || null,
+      },
+      manifestUrl:
+        session.artifacts?.session_manifest || session.artifacts?.manifest || session.manifestUrl || null,
       firstAudioUrl: session.turns.find(t => Boolean(t.audio))?.audio || null,
+      sessionAudioUrl: session.artifacts?.session_audio || null,
     })
   }
 
@@ -40,6 +50,6 @@ export async function GET() {
     const raw = (globalThis as any)?.localStorage?.getItem?.('demoHistory')
     if (raw) demo = JSON.parse(raw)
   } catch {}
-  const demoRows = (demo||[]).map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{ transcript_txt:false, transcript_json:false } }))
+  const demoRows = (demo||[]).map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{ transcript_txt: null, transcript_json: null } }))
   return NextResponse.json({ items: [...demoRows, ...rows] })
 }

--- a/app/api/save-session-audio/route.ts
+++ b/app/api/save-session-audio/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { putBlobFromBuffer } from '@/lib/blob'
+
+const schema = z.object({
+  sessionId: z.string().min(1),
+  audio: z.string().min(1),
+  mime: z.string().default('audio/webm'),
+  duration_ms: z.number().nonnegative().optional(),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { sessionId, audio, mime, duration_ms } = schema.parse(body)
+
+    const buffer = Buffer.from(audio, 'base64')
+    const ext = mime.split('/')[1]?.split(';')[0] || 'webm'
+    const blob = await putBlobFromBuffer(
+      `sessions/${sessionId}/session-audio.${ext}`,
+      buffer,
+      mime,
+      { access: 'public' },
+    )
+
+    const url = blob.downloadUrl || blob.url
+    return NextResponse.json({ ok: true, url, durationMs: duration_ms ?? null })
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err?.message || 'save_failed' }, { status: 400 })
+  }
+}

--- a/app/api/session/[id]/finalize/route.ts
+++ b/app/api/session/[id]/finalize/route.ts
@@ -5,9 +5,12 @@ import { z } from 'zod'
 export async function POST(req: NextRequest, { params }: { params: { id: string }}) {
   try {
     const body = await req.json()
-    const schema = z.object({ clientDurationMs: z.number().nonnegative().default(0) })
-    const { clientDurationMs } = schema.parse(body)
-    const result = await finalizeSession(params.id, { clientDurationMs })
+    const schema = z.object({
+      clientDurationMs: z.number().nonnegative().default(0),
+      sessionAudioUrl: z.string().min(1).optional(),
+    })
+    const { clientDurationMs, sessionAudioUrl } = schema.parse(body)
+    const result = await finalizeSession(params.id, { clientDurationMs, sessionAudioUrl })
     return NextResponse.json(result)
   } catch (e:any) {
     return NextResponse.json({ error: e?.message ?? 'bad_request' }, { status: 400 })

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { synthesizeSpeechWithOpenAi } from '@/lib/openaiTts'
+
+const schema = z.object({
+  text: z.string().min(1),
+  voice: z.string().optional(),
+  format: z.enum(['mp3', 'opus', 'aac', 'flac', 'wav']).optional(),
+  model: z.string().optional(),
+  speed: z.number().positive().max(4).optional(),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { text, voice, format = 'mp3', model, speed } = schema.parse(body)
+
+    const buffer = await synthesizeSpeechWithOpenAi({ text, voice: voice as any, format, model, speed })
+    const audioBase64 = buffer.toString('base64')
+    const mime = format === 'mp3' ? 'audio/mpeg' : `audio/${format}`
+
+    return NextResponse.json({ ok: true, audioBase64, mime, format })
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err?.message || 'tts_failed' }, { status: 400 })
+  }
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -7,9 +7,15 @@ type Row = {
   title: string | null
   status: string
   total_turns: number
-  artifacts: { transcript_txt: boolean; transcript_json: boolean }
+  artifacts: {
+    transcript_txt?: string | null
+    transcript_json?: string | null
+    session_manifest?: string | null
+    session_audio?: string | null
+  }
   manifestUrl?: string | null
   firstAudioUrl?: string | null
+  sessionAudioUrl?: string | null
 }
 
 export default function HistoryPage() {
@@ -25,7 +31,7 @@ export default function HistoryPage() {
           const raw = localStorage.getItem('demoHistory')
           if (raw) {
             const list = JSON.parse(raw) as { id:string, created_at:string }[]
-            demoRows = list.map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{ transcript_txt:false, transcript_json:false } }))
+            demoRows = list.map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{} }))
           }
         } catch {}
         setRows([...(demoRows||[]), ...(serverRows||[])])
@@ -55,9 +61,16 @@ export default function HistoryPage() {
                   <div className="text-xs opacity-70">Turns: {s.total_turns} • Status: {s.status}</div>
                 </div>
                 <div className="flex flex-wrap gap-2 text-sm">
-                  <a className="underline" href={`/session/${s.id}`}>Open</a>
-                  {s.manifestUrl && (
-                    <a className="underline" href={s.manifestUrl} target="_blank" rel="noreferrer">
+                  <a className="underline" href={`/session/${s.id}`}>
+                    Open
+                  </a>
+                  {(s.manifestUrl || s.artifacts?.session_manifest) && (
+                    <a
+                      className="underline"
+                      href={(s.manifestUrl || s.artifacts?.session_manifest) ?? undefined}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       Session manifest
                     </a>
                   )}
@@ -66,8 +79,26 @@ export default function HistoryPage() {
                       First turn audio
                     </a>
                   )}
-                  {s.artifacts?.transcript_txt && <a className="underline" href="#">Transcript (txt)</a>}
-                  {s.artifacts?.transcript_json && <a className="underline" href="#">Transcript (json)</a>}
+                  {s.artifacts?.transcript_txt && (
+                    <a className="underline" href={s.artifacts.transcript_txt} target="_blank" rel="noreferrer">
+                      Transcript (txt)
+                    </a>
+                  )}
+                  {s.artifacts?.transcript_json && (
+                    <a className="underline" href={s.artifacts.transcript_json} target="_blank" rel="noreferrer">
+                      Transcript (json)
+                    </a>
+                  )}
+                  {(s.sessionAudioUrl || s.artifacts?.session_audio) && (
+                    <a
+                      className="underline"
+                      href={(s.sessionAudioUrl || s.artifacts?.session_audio) ?? undefined}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Session audio
+                    </a>
+                  )}
                 </div>
               </div>
             </li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,16 @@
 "use client"
-import { useInterviewMachine } from '@/lib/machine'
-import { speak } from '@/lib/tts'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useInterviewMachine } from '@/lib/machine'
 import { calibrateRMS, recordUntilSilence, blobToBase64 } from '@/lib/audio-bridge'
+import { createSessionRecorder, SessionRecorder } from '@/lib/session-recorder'
 
-// DEMO/TEST MODE: Shortened greeting for faster testing
 const OPENING = `Start testing greeting. Answer a question.`
+
+type AssistantPlayback = {
+  base64: string | null
+  mime: string
+  durationMs: number
+}
 
 export default function Home() {
   const m = useInterviewMachine()
@@ -14,60 +19,17 @@ export default function Home() {
   const [hasStarted, setHasStarted] = useState(false)
   const [disabledNext, setDisabledNext] = useState(false)
   const inTurnRef = useRef(false)
-  // DEMO/TEST MODE: only 1 turn before finalize
+  const recorderRef = useRef<SessionRecorder | null>(null)
+  const sessionAudioUrlRef = useRef<string | null>(null)
+  const sessionAudioDurationRef = useRef<number>(0)
+
   const MAX_TURNS = 1
 
-  async function finalizeNow(){
-    if (!sessionId) return
-    try{
-      const [legacyRes, memRes] = await Promise.allSettled([
-        fetch(`/api/finalize-session`, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ sessionId }) }),
-        fetch(`/api/session/${sessionId}/finalize`, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ clientDurationMs: 0 }) })
-      ])
-
-      async function inspect(label: string, result: PromiseSettledResult<Response>) {
-        if (result.status !== 'fulfilled') {
-          const reason = result.reason instanceof Error ? result.reason.message : 'request_failed'
-          m.pushLog(`${label} failed: ${reason}`)
-          return false
-        }
-        let payload: any = null
-        try {
-          payload = await result.value.clone().json()
-          m.pushLog(`${label}: ` + JSON.stringify(payload))
-        } catch {}
-        if (!result.value.ok || (payload && payload.ok === false)) {
-          m.pushLog(`${label} not ok (status ${result.value.status})`)
-          return false
-        }
-        return true
-      }
-
-      const legacyOk = await inspect('Finalized (blob)', legacyRes)
-      const memOk = await inspect('Finalized (mem)', memRes)
-      if (!legacyOk || !memOk) throw new Error('Finalize failed')
-
-      // DEMO: also persist a minimal client-side history record so History page has entries even without server memory/blob
-      try {
-        const demo = JSON.parse(localStorage.getItem('demoHistory')||'[]')
-        const stamp = new Date().toISOString()
-        demo.unshift({ id: sessionId, created_at: stamp })
-        localStorage.setItem('demoHistory', JSON.stringify(demo.slice(0,50)))
-      } catch {}
-      m.toDone()
-      setDisabledNext(false)
-    }catch{
-      m.pushLog('Finalize failed')
-      setDisabledNext(false)
-    }
-  }
-
-  // Create a server-backed session id (for history), fallback to existing client id
   useEffect(() => {
     try {
       fetch('/api/session/start', { method: 'POST' })
-        .then(r=>r.json())
-        .then(d => {
+        .then((r) => r.json())
+        .then((d) => {
           const id = d?.id || crypto.randomUUID()
           sessionStorage.setItem('sessionId', id)
           setSessionId(id)
@@ -78,12 +40,252 @@ export default function Home() {
           const id = existing || crypto.randomUUID()
           sessionStorage.setItem('sessionId', id)
           setSessionId(id)
-          m.pushLog('Session started: ' + id)
+          m.pushLog('Session started (fallback): ' + id)
         })
     } catch {}
+  }, [m])
+
+  useEffect(() => {
+    return () => {
+      try {
+        recorderRef.current?.cancel()
+      } catch {}
+      recorderRef.current = null
+    }
   }, [])
 
-  // No auto-start; greeting is spoken on first Next click
+  const ensureSessionRecorder = useCallback(async () => {
+    if (typeof window === 'undefined') return null
+    if (!recorderRef.current) {
+      recorderRef.current = createSessionRecorder()
+    }
+    try {
+      await recorderRef.current.start()
+      return recorderRef.current
+    } catch (err) {
+      recorderRef.current?.cancel()
+      recorderRef.current = null
+      throw err
+    }
+  }, [])
+
+  const playWithAudioElement = useCallback(async (base64: string, mime: string) => {
+    if (typeof window === 'undefined') return 0
+    return await new Promise<number>((resolve) => {
+      try {
+        const src = `data:${mime};base64,${base64}`
+        const audio = new Audio(src)
+        audio.onended = () => {
+          resolve(Math.round((audio.duration || 0) * 1000))
+        }
+        audio.onerror = () => resolve(0)
+        audio.play().catch(() => resolve(0))
+      } catch {
+        resolve(0)
+      }
+    })
+  }, [])
+
+  const playWithSpeechSynthesis = useCallback(async (text: string) => {
+    if (typeof window === 'undefined') return 0
+    return await new Promise<number>((resolve) => {
+      try {
+        if (!('speechSynthesis' in window)) {
+          resolve(0)
+          return
+        }
+        const utterance = new SpeechSynthesisUtterance(text)
+        utterance.rate = 1
+        utterance.pitch = 1
+        utterance.onend = () => resolve(0)
+        utterance.onerror = () => resolve(0)
+        window.speechSynthesis.cancel()
+        window.speechSynthesis.speak(utterance)
+      } catch {
+        resolve(0)
+      }
+    })
+  }, [])
+
+  const playAssistantResponse = useCallback(
+    async (text: string): Promise<AssistantPlayback> => {
+      if (!text) return { base64: null, mime: 'audio/mpeg', durationMs: 0 }
+      m.pushLog('Assistant reply ready → playing')
+      try {
+        const res = await fetch('/api/tts', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ text }),
+        })
+        if (!res.ok) throw new Error('tts_failed')
+        const data = await res.json()
+        if (!data?.audioBase64 || typeof data.audioBase64 !== 'string') {
+          throw new Error('tts_invalid')
+        }
+        const mime = typeof data.mime === 'string' ? data.mime : 'audio/mpeg'
+        let durationMs = 0
+        const recorder = recorderRef.current
+        if (recorder) {
+          try {
+            const playback = await recorder.playAssistantBase64(data.audioBase64, mime)
+            durationMs = playback?.durationMs ?? 0
+          } catch (err) {
+            m.pushLog('Recorder playback failed, falling back to direct audio')
+            durationMs = await playWithAudioElement(data.audioBase64, mime)
+          }
+        } else {
+          durationMs = await playWithAudioElement(data.audioBase64, mime)
+        }
+        return { base64: data.audioBase64, mime, durationMs }
+      } catch (err) {
+        m.pushLog('TTS unavailable, using speech synthesis fallback')
+        const durationMs = await playWithSpeechSynthesis(text)
+        return { base64: null, mime: 'audio/mpeg', durationMs }
+      }
+    },
+    [m, playWithAudioElement, playWithSpeechSynthesis],
+  )
+
+  const finalizeNow = useCallback(async () => {
+    if (!sessionId) return
+    setDisabledNext(true)
+    try {
+      let sessionAudioUrl = sessionAudioUrlRef.current
+      let sessionAudioDurationMs = sessionAudioDurationRef.current
+
+      if (!sessionAudioUrl && recorderRef.current) {
+        try {
+          const recording = await recorderRef.current.stop()
+          recorderRef.current = null
+          const base64 = await blobToBase64(recording.blob)
+          sessionAudioDurationMs = recording.durationMs
+          if (base64) {
+            const saveRes = await fetch('/api/save-session-audio', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                sessionId,
+                audio: base64,
+                mime: recording.mimeType || 'audio/webm',
+                duration_ms: recording.durationMs,
+              }),
+            })
+            const saveJson = await saveRes.json().catch(() => null)
+            if (saveRes.ok && saveJson?.ok) {
+              sessionAudioUrl = typeof saveJson.url === 'string' ? saveJson.url : null
+              if (typeof saveJson?.durationMs === 'number') {
+                sessionAudioDurationMs = saveJson.durationMs
+              }
+            } else {
+              m.pushLog('Failed to store session audio')
+            }
+          }
+        } catch (err) {
+          m.pushLog('Session audio capture failed')
+          try {
+            recorderRef.current?.cancel()
+          } catch {}
+          recorderRef.current = null
+        }
+      }
+
+      sessionAudioUrlRef.current = sessionAudioUrl
+      sessionAudioDurationRef.current = sessionAudioDurationMs
+
+      const payload = {
+        sessionId,
+        sessionAudioUrl: sessionAudioUrl || undefined,
+        sessionAudioDurationMs: sessionAudioDurationMs || undefined,
+      }
+
+      async function inspect(label: string, response: Response | null, options?: { optional?: boolean }) {
+        if (!response) {
+          m.pushLog(`${label} failed: no response`)
+          return false
+        }
+        let payload: any = null
+        let logged = false
+        try {
+          payload = await response.clone().json()
+          m.pushLog(`${label}: ` + JSON.stringify(payload))
+          logged = true
+        } catch {
+          try {
+            const text = await response.clone().text()
+            if (text.trim().length) {
+              m.pushLog(`${label}: ${text}`)
+              logged = true
+            }
+          } catch {}
+        }
+        if (!logged) {
+          m.pushLog(`${label}: status ${response.status}`)
+        }
+
+        const payloadError = payload && typeof payload.error === 'string' ? payload.error : null
+        const shouldIgnoreMissingSession =
+          options?.optional && payloadError && /session not found/i.test(payloadError)
+
+        if (!response.ok || (payload && payload.ok === false)) {
+          if (shouldIgnoreMissingSession) {
+            m.pushLog(`${label} skipped (stateless runtime)`)
+            return true
+          }
+          m.pushLog(`${label} not ok (status ${response.status})`)
+          return false
+        }
+        return true
+      }
+
+      let legacyRes: Response | null = null
+      try {
+        legacyRes = await fetch(`/api/finalize-session`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'request_failed'
+        m.pushLog(`Finalized (blob) failed: ${message}`)
+        throw err
+      }
+
+      const legacyOk = await inspect('Finalized (blob)', legacyRes)
+      if (!legacyOk) throw new Error('Finalize failed')
+
+      let memOk = true
+      try {
+        const memRes = await fetch(`/api/session/${sessionId}/finalize`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            clientDurationMs: sessionAudioDurationMs,
+            sessionAudioUrl: sessionAudioUrl || undefined,
+          }),
+        })
+        memOk = await inspect('Finalized (mem)', memRes, { optional: true })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'request_failed'
+        m.pushLog(`Finalized (mem) failed: ${message}`)
+        memOk = false
+      }
+
+      if (!memOk) throw new Error('Finalize failed')
+
+      try {
+        const demo = JSON.parse(localStorage.getItem('demoHistory') || '[]')
+        const stamp = new Date().toISOString()
+        demo.unshift({ id: sessionId, created_at: stamp })
+        localStorage.setItem('demoHistory', JSON.stringify(demo.slice(0, 50)))
+      } catch {}
+
+      m.toDone()
+    } catch {
+      m.pushLog('Finalize failed')
+    } finally {
+      setDisabledNext(false)
+    }
+  }, [m, sessionId])
 
   const runTurnLoop = useCallback(async () => {
     if (!sessionId) return
@@ -96,7 +298,13 @@ export default function Home() {
       let recDuration = 0
       try {
         const baseline = await calibrateRMS(0.5)
-        const rec = await recordUntilSilence({ baseline, minDurationMs:600, silenceMs:800, graceMs:200, shouldForceStop: ()=> false })
+        const rec = await recordUntilSilence({
+          baseline,
+          minDurationMs: 600,
+          silenceMs: 800,
+          graceMs: 200,
+          shouldForceStop: () => false,
+        })
         b64 = await blobToBase64(rec.blob)
         recDuration = rec.durationMs || 0
       } catch {
@@ -107,74 +315,111 @@ export default function Home() {
       m.pushLog('Recording stopped → thinking')
 
       const askRes = await fetch('/api/ask-audio', {
-        method: 'POST', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ audio: b64, format: 'webm', sessionId, turn: turn+1 })
-      }).then(r=>r.json()).catch(()=>({ reply:"Tell me one small detail you remember from that moment.", transcript:"", end_intent:false }))
-      const reply: string = askRes?.reply || "Tell me one small detail you remember from that moment."
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ audio: b64, format: 'webm', sessionId, turn: turn + 1 }),
+      })
+        .then((r) => r.json())
+        .catch(() => ({ reply: 'Tell me one small detail you remember from that moment.', transcript: '', end_intent: false }))
+
+      const reply: string = askRes?.reply || 'Tell me one small detail you remember from that moment.'
       const transcript: string = askRes?.transcript || ''
       const endIntent: boolean = askRes?.end_intent === true
       const endRegex = /(i[' ]?m done|stop for now|that's all|i'm finished|we're done|let's stop)/i
 
-      // Persist artifacts and history (non-fatal if any fail)
+      let assistantPlayback: AssistantPlayback = { base64: null, mime: 'audio/mpeg', durationMs: 0 }
+      try {
+        assistantPlayback = await playAssistantResponse(reply)
+      } catch {
+        assistantPlayback = { base64: null, mime: 'audio/mpeg', durationMs: 0 }
+      }
+
       const persistPromises: Promise<any>[] = []
-      persistPromises.push(fetch('/api/save-turn', {
-        method: 'POST', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ sessionId, turn: turn+1, wav: b64, mime:'audio/webm', duration_ms: recDuration, reply_text: reply, transcript, provider: 'google' })
-      }))
-      persistPromises.push(fetch(`/api/session/${sessionId}/turn`, {
-        method: 'POST', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ role:'user', text: transcript || '' })
-      }))
-      persistPromises.push(fetch(`/api/session/${sessionId}/turn`, {
-        method: 'POST', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ role:'assistant', text: reply || '' })
-      }))
-      try { await Promise.allSettled(persistPromises) } catch {}
+      persistPromises.push(
+        fetch('/api/save-turn', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            sessionId,
+            turn: turn + 1,
+            wav: b64,
+            mime: 'audio/webm',
+            duration_ms: recDuration,
+            reply_text: reply,
+            transcript,
+            provider: 'google',
+            assistant_wav: assistantPlayback.base64 || undefined,
+            assistant_mime: assistantPlayback.mime || undefined,
+            assistant_duration_ms: assistantPlayback.durationMs || 0,
+          }),
+        }),
+      )
+      persistPromises.push(
+        fetch(`/api/session/${sessionId}/turn`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ role: 'user', text: transcript || '' }),
+        }),
+      )
+      persistPromises.push(
+        fetch(`/api/session/${sessionId}/turn`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ role: 'assistant', text: reply || '' }),
+        }),
+      )
+      try {
+        await Promise.allSettled(persistPromises)
+      } catch {}
 
       const nextTurn = turn + 1
       setTurn(nextTurn)
 
-      const u = new SpeechSynthesisUtterance(reply)
-      u.rate = 1; u.pitch = 1
-      u.onend = () => {
-        m.pushLog('Finished playing → ready')
-        const reachedMax = nextTurn >= MAX_TURNS
-        const shouldEnd = endIntent || reachedMax || (transcript && endRegex.test(transcript))
-        inTurnRef.current = false
-        if (shouldEnd) finalizeNow()
+      m.pushLog('Finished playing → ready')
+      const reachedMax = nextTurn >= MAX_TURNS
+      const shouldEnd = endIntent || reachedMax || (transcript && endRegex.test(transcript))
+      inTurnRef.current = false
+
+      if (shouldEnd) {
+        await finalizeNow()
+      } else {
+        setDisabledNext(false)
       }
-      try {
-        window.speechSynthesis.cancel();
-        window.speechSynthesis.speak(u);
-        // TODO(later): offer an opt-in flag here that pipes the assistant response through
-        // the OpenAI NeuralHD voices for higher fidelity playback once the backend wiring is ready.
-      } catch {}
-      m.pushLog('Assistant reply ready → playing')
     } catch (e) {
       m.pushLog('There was a problem saving or asking. Check /api/health and env keys.')
       inTurnRef.current = false
       setDisabledNext(false)
     }
-  }, [m, sessionId, turn])
+  }, [MAX_TURNS, finalizeNow, m, playAssistantResponse, sessionId, turn])
 
-  // Single-button flow handler
-  const onNext = useCallback(() => {
+  const startSession = useCallback(async () => {
+    if (hasStarted) return
+    setHasStarted(true)
+    setDisabledNext(true)
+    try {
+      try {
+        await ensureSessionRecorder()
+      } catch {
+        m.pushLog('Session recorder unavailable; proceeding without combined audio')
+      }
+      await playAssistantResponse(OPENING)
+    } catch {
+      await playWithSpeechSynthesis(OPENING)
+    } finally {
+      setDisabledNext(false)
+    }
+  }, [ensureSessionRecorder, hasStarted, m, playAssistantResponse, playWithSpeechSynthesis])
+
+  const onNext = useCallback(async () => {
     if (disabledNext) return
     if (!hasStarted) {
-      setHasStarted(true)
-      try {
-        const u = new SpeechSynthesisUtterance(OPENING)
-        u.rate = 1; u.pitch = 1
-        window.speechSynthesis.cancel();
-        window.speechSynthesis.speak(u);
-        // REMINDER: consider progressive playback (streaming audio chunks) so the UI stays responsive
-        // when we switch to OpenAI-powered TTS.
-        m.pushLog('Assistant reply ready → playing')
-      } catch {}
+      await startSession()
       return
     }
-    if (!inTurnRef.current) runTurnLoop()
-  }, [hasStarted, runTurnLoop, disabledNext])
+    if (!inTurnRef.current) {
+      await runTurnLoop()
+    }
+  }, [disabledNext, hasStarted, runTurnLoop, startSession])
 
   return (
     <main className="mt-8">
@@ -183,16 +428,34 @@ export default function Home() {
 
         <div className="flex gap-3">
           {m.state !== 'doneSuccess' ? (
-            <button onClick={onNext} disabled={disabledNext} className="text-sm bg-white/10 px-3 py-1 rounded-2xl disabled:opacity-50">Next</button>
+            <button onClick={onNext} disabled={disabledNext} className="text-sm bg-white/10 px-3 py-1 rounded-2xl disabled:opacity-50">
+              Next
+            </button>
           ) : (
-            <button onClick={()=>{ setHasStarted(false); setTurn(0); }} className="text-sm bg-white/10 px-3 py-1 rounded-2xl">Start Again</button>
+            <button
+              onClick={() => {
+                try {
+                  recorderRef.current?.cancel()
+                } catch {}
+                recorderRef.current = null
+                sessionAudioUrlRef.current = null
+                sessionAudioDurationRef.current = 0
+                setHasStarted(false)
+                setTurn(0)
+              }}
+              className="text-sm bg-white/10 px-3 py-1 rounded-2xl"
+            >
+              Start Again
+            </button>
           )}
         </div>
 
         <div className="w-full max-w-xl">
           <label className="text-xs opacity-70">On-screen Log (copy to share diagnostics):</label>
           <textarea value={m.debugLog.join('\n')} readOnly className="w-full h-56 bg-black/30 p-2 rounded" />
-          <div className="mt-2 text-xs opacity-70">Need more? Visit <a className="underline" href="/diagnostics">Diagnostics</a>.</div>
+          <div className="mt-2 text-xs opacity-70">
+            Need more? Visit <a className="underline" href="/diagnostics">Diagnostics</a>.
+          </div>
         </div>
       </div>
     </main>

--- a/app/session/[id]/page.tsx
+++ b/app/session/[id]/page.tsx
@@ -26,8 +26,15 @@ export default async function SessionPage({ params }: { params: { id: string } }
       <div className="mt-4 flex flex-wrap gap-3 text-sm">
         {s.artifacts?.transcript_txt && <a className="underline" href={s.artifacts.transcript_txt}>Transcript (txt)</a>}
         {s.artifacts?.transcript_json && <a className="underline" href={s.artifacts.transcript_json}>Transcript (json)</a>}
-        {s.artifacts?.manifest && (
-          <a className="underline" href={s.artifacts.manifest}>Session manifest</a>
+        {(s.artifacts?.manifest || s.artifacts?.session_manifest) && (
+          <a className="underline" href={(s.artifacts.manifest || s.artifacts.session_manifest)!}>
+            Session manifest
+          </a>
+        )}
+        {s.artifacts?.session_audio && (
+          <a className="underline" href={s.artifacts.session_audio} target="_blank" rel="noreferrer">
+            Session audio
+          </a>
         )}
       </div>
     </main>

--- a/lib/blob.ts
+++ b/lib/blob.ts
@@ -1,35 +1,125 @@
-import { put, list } from '@vercel/blob'
+import { put, list as vercelList, type ListBlobResult, type ListCommandOptions } from '@vercel/blob'
+
+export type PutBlobOptions = {
+  access?: 'public'
+  addRandomSuffix?: boolean
+  cacheControlMaxAge?: number
+}
+
+type MemoryBlobRecord = {
+  buffer: Buffer
+  contentType: string
+  uploadedAt: Date
+  size: number
+  dataUrl: string
+}
+
+const GLOBAL_STORE_KEY = '__dads_interview_blob_fallback__'
+const globalAny = globalThis as any
+if (!globalAny[GLOBAL_STORE_KEY]) {
+  globalAny[GLOBAL_STORE_KEY] = new Map<string, MemoryBlobRecord>()
+}
+const memoryStore: Map<string, MemoryBlobRecord> = globalAny[GLOBAL_STORE_KEY]
+
+function buildInlineDataUrl(contentType: string, buffer: Buffer): string {
+  const safeType = contentType && contentType.length ? contentType : 'application/octet-stream'
+  const base64 = buffer.toString('base64')
+  return `data:${safeType};base64,${base64}`
+}
+
+export function getBlobToken() {
+  return process.env.VERCEL_BLOB_READ_WRITE_TOKEN || process.env.BLOB_READ_WRITE_TOKEN
+}
+
+export function getFallbackBlob(path: string): (MemoryBlobRecord & { pathname: string }) | undefined {
+  const record = memoryStore.get(path)
+  if (!record) return undefined
+  return { ...record, pathname: path }
+}
+
+export function clearFallbackBlobs() {
+  memoryStore.clear()
+}
 
 export async function putBlobFromBuffer(
   path: string,
   buf: Buffer,
   contentType: string,
-  options: {
-    access?: 'public'
-    addRandomSuffix?: boolean
-    cacheControlMaxAge?: number
-  } = {}
+  options: PutBlobOptions = {},
 ) {
   const access = options.access ?? 'public'
-  if (!process.env.VERCEL_BLOB_READ_WRITE_TOKEN) {
-    return { url: `data:${contentType};base64,` + buf.toString('base64') }
+  const token = getBlobToken()
+
+  if (!token) {
+    const bufferCopy = Buffer.from(buf)
+    const dataUrl = buildInlineDataUrl(contentType, bufferCopy)
+    const record: MemoryBlobRecord = {
+      buffer: bufferCopy,
+      contentType,
+      uploadedAt: new Date(),
+      size: bufferCopy.byteLength,
+      dataUrl,
+    }
+    memoryStore.set(path, record)
+    return {
+      url: dataUrl,
+      downloadUrl: dataUrl,
+    }
   }
-  const res = await put(path, buf, {
+
+  const result = await put(path, buf, {
     access,
-    token: process.env.VERCEL_BLOB_READ_WRITE_TOKEN,
+    token,
     contentType,
     addRandomSuffix: options.addRandomSuffix,
     cacheControlMaxAge: options.cacheControlMaxAge,
   })
-  return { url: res.url, downloadUrl: res.downloadUrl }
+
+  return { url: result.url, downloadUrl: result.downloadUrl }
+}
+
+export async function listBlobs(options: ListCommandOptions | undefined = {}): Promise<ListBlobResult> {
+  const token = getBlobToken()
+
+  if (!token) {
+    const prefix = options?.prefix ?? ''
+    const limit = typeof options?.limit === 'number' ? options.limit : undefined
+
+    const entries = Array.from(memoryStore.entries())
+      .filter(([pathname]) => !prefix || pathname.startsWith(prefix))
+      .sort((a, b) => b[1].uploadedAt.getTime() - a[1].uploadedAt.getTime())
+
+    const sliced = typeof limit === 'number' ? entries.slice(0, Math.max(limit, 0)) : entries
+    return {
+      blobs: sliced.map(([pathname, record]) => {
+        const url = record.dataUrl
+        return {
+          pathname,
+          url,
+          downloadUrl: url,
+          uploadedAt: record.uploadedAt,
+          size: record.size,
+        }
+      }),
+      hasMore: typeof limit === 'number' ? entries.length > limit : false,
+      cursor: undefined,
+    }
+  }
+
+  const listOptions: ListCommandOptions = { ...(options || {}), token }
+  return vercelList(listOptions)
 }
 
 export async function blobHealth() {
+  const token = getBlobToken()
+  if (!token) {
+    return { ok: true, mode: 'memory', reason: 'no token' }
+  }
+
   try {
-    if (!process.env.VERCEL_BLOB_READ_WRITE_TOKEN) return { ok: false, reason: 'no token' }
-    await list({ token: process.env.VERCEL_BLOB_READ_WRITE_TOKEN })
-    return { ok: true }
-  } catch (e:any) {
+    await vercelList({ limit: 1, token })
+    return { ok: true, mode: 'vercel' }
+  } catch (e: any) {
     return { ok: false, reason: e?.message || 'error' }
   }
 }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,46 +1,66 @@
-import { putBlobFromBuffer } from './blob'
+import { putBlobFromBuffer, listBlobs } from './blob'
 import { sendSummaryEmail } from './email'
-import { fetchStoredSession } from './history'
 
-type Session = {
+export type Session = {
   id: string
   created_at: string
   title?: string
   email_to: string
-  status: 'in_progress'|'completed'|'emailed'|'error'
+  status: 'in_progress' | 'completed' | 'emailed' | 'error'
   duration_ms: number
   total_turns: number
   artifacts?: Record<string, string>
   turns?: Turn[]
 }
-type Turn = {
+export type Turn = {
   id: string
-  role: 'user'|'assistant'
+  role: 'user' | 'assistant'
   text: string
   audio_blob_url?: string
 }
 
-// Ensure the in-memory store survives hot reloads/dev and is shared across route invocations
+type SessionPatch = {
+  artifacts?: Record<string, string | null | undefined>
+  totalTurns?: number
+  durationMs?: number
+  status?: Session['status']
+}
+
+type ManifestLookup = { id: string; uploadedAt?: string; url: string; data: any }
+
+type RememberedSession = Session & { turns?: Turn[] }
+
 const globalKey = '__dads_interview_mem__'
-// @ts-ignore
 const g: any = globalThis as any
 if (!g[globalKey]) {
-  // @ts-ignore
-  g[globalKey] = { sessions: new Map<string, Session>() }
+  g[globalKey] = { sessions: new Map<string, RememberedSession>() }
 }
-// @ts-ignore
-const mem: { sessions: Map<string, Session> } = g[globalKey]
+const mem: { sessions: Map<string, RememberedSession> } = g[globalKey]
 
-function uid() { return Math.random().toString(36).slice(2) + Date.now().toString(36) }
+function uid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
 
-export async function dbHealth() { return { ok: true, mode: 'memory' } }
+function inlineAwareLabel(label: string, value: string | undefined | null) {
+  if (!value) return `${label}: unavailable`
+  if (value.startsWith('data:')) return `${label}: [inline]`
+  return `${label}: ${value}`
+}
 
-export async function createSession({ email_to }:{ email_to: string}): Promise<Session> {
-  const s: Session = {
+export async function dbHealth() {
+  return { ok: true, mode: 'memory' }
+}
+
+export async function createSession({ email_to }: { email_to: string }): Promise<Session> {
+  const s: RememberedSession = {
     id: uid(),
     created_at: new Date().toISOString(),
-    email_to, status: 'in_progress',
-    duration_ms: 0, total_turns: 0, turns: [], artifacts: {},
+    email_to,
+    status: 'in_progress',
+    duration_ms: 0,
+    total_turns: 0,
+    turns: [],
+    artifacts: {},
   }
   mem.sessions.set(s.id, s)
   return s
@@ -49,12 +69,19 @@ export async function createSession({ email_to }:{ email_to: string}): Promise<S
 export async function appendTurn(id: string, turn: Partial<Turn>) {
   const s = mem.sessions.get(id)
   if (!s) throw new Error('Session not found')
-  const t: Turn = { id: uid(), role: (turn.role as any) || 'user', text: turn.text || '', audio_blob_url: turn.audio_blob_url }
-  s.turns!.push(t); s.total_turns = s.turns!.length
+  const t: Turn = {
+    id: uid(),
+    role: (turn.role as any) || 'user',
+    text: turn.text || '',
+    audio_blob_url: turn.audio_blob_url,
+  }
+  if (!s.turns) s.turns = []
+  s.turns.push(t)
+  s.total_turns = s.turns.length
   return t
 }
 
-export async function finalizeSession(id: string, body: { clientDurationMs: number }) {
+export async function finalizeSession(id: string, body: { clientDurationMs: number; sessionAudioUrl?: string | null }) {
   const s = mem.sessions.get(id)
   if (!s) throw new Error('Session not found')
   const turns = s.turns || []
@@ -62,29 +89,62 @@ export async function finalizeSession(id: string, body: { clientDurationMs: numb
   s.duration_ms = safeDuration
   s.status = 'completed'
 
-  const txt = turns.map(t => `${t.role}: ${t.text}`).join('\n')
+  const txt = turns.map((t) => `${t.role}: ${t.text}`).join('\n')
   const jsonObj = { sessionId: s.id, created_at: s.created_at, total_turns: turns.length, turns }
   const txtBuf = Buffer.from(txt, 'utf8')
   const jsonBuf = Buffer.from(JSON.stringify(jsonObj, null, 2), 'utf8')
 
-  const txtBlob = await putBlobFromBuffer(`transcripts/${s.id}.txt`, txtBuf, 'text/plain; charset=utf-8', { access: 'public' })
+  const txtBlob = await putBlobFromBuffer(`transcripts/${s.id}.txt`, txtBuf, 'text/plain; charset=utf-8', {
+    access: 'public',
+  })
   const jsonBlob = await putBlobFromBuffer(`transcripts/${s.id}.json`, jsonBuf, 'application/json', { access: 'public' })
 
-  s.artifacts = { transcript_txt: txtBlob.url, transcript_json: jsonBlob.url }
+  const transcriptTxtUrl = txtBlob.downloadUrl || txtBlob.url
+  const transcriptJsonUrl = jsonBlob.downloadUrl || jsonBlob.url
+
+  s.artifacts = {
+    ...s.artifacts,
+    transcript_txt: transcriptTxtUrl,
+    transcript_json: transcriptJsonUrl,
+  }
+  if (body.sessionAudioUrl) {
+    s.artifacts.session_audio = body.sessionAudioUrl
+  }
   s.total_turns = turns.length
+
+  const manifestBody = {
+    sessionId: s.id,
+    created_at: s.created_at,
+    email: s.email_to,
+    totals: { turns: turns.length, durationMs: s.duration_ms },
+    turns: turns.map((t) => ({ id: t.id, role: t.role, text: t.text, audio: t.audio_blob_url || null })),
+    artifacts: s.artifacts,
+    status: s.status,
+  }
+  const manifestBlob = await putBlobFromBuffer(
+    `sessions/${s.id}/session-${s.id}.json`,
+    Buffer.from(JSON.stringify(manifestBody, null, 2), 'utf8'),
+    'application/json',
+    { access: 'public' },
+  )
+  const manifestUrl = manifestBlob.downloadUrl || manifestBlob.url
+  s.artifacts.session_manifest = manifestUrl
+
+  rememberSessionManifest(manifestBody, s.id, s.created_at, manifestUrl)
 
   const date = new Date(s.created_at).toLocaleString()
   const bodyText = [
     `Your interview session (${date})`,
     `Turns: ${s.total_turns}`,
-    `Duration: ${Math.round(s.duration_ms/1000)}s`,
-    `Transcript (txt): ${s.artifacts.transcript_txt}`,
-    `Transcript (json): ${s.artifacts.transcript_json}`,
+    `Duration: ${Math.round(s.duration_ms / 1000)}s`,
+    inlineAwareLabel('Transcript (txt)', s.artifacts.transcript_txt),
+    inlineAwareLabel('Transcript (json)', s.artifacts.transcript_json),
+    inlineAwareLabel('Session audio', s.artifacts.session_audio),
   ].join('\n')
   let emailStatus: Awaited<ReturnType<typeof sendSummaryEmail>> | { ok: false; provider: 'unknown'; error: string }
   try {
     emailStatus = await sendSummaryEmail(s.email_to, `Interview session – ${date}`, bodyText)
-  } catch (e:any) {
+  } catch (e: any) {
     emailStatus = { ok: false, provider: 'unknown', error: e?.message || 'send_failed' }
   }
 
@@ -102,46 +162,209 @@ export async function finalizeSession(id: string, body: { clientDurationMs: numb
   return { ok: true, session: s, emailed, emailStatus }
 }
 
-export async function listSessions(): Promise<Session[]> {
-  return Array.from(mem.sessions.values()).sort((a,b)=> (a.created_at < b.created_at ? 1 : -1))
+export function mergeSessionArtifacts(id: string, patch: SessionPatch) {
+  const session = mem.sessions.get(id)
+  if (!session) return
+  if (patch.artifacts) {
+    const filteredEntries = Object.entries(patch.artifacts).filter(
+      ([, value]) => typeof value === 'string' && value.length > 0,
+    ) as [string, string][]
+    if (filteredEntries.length) {
+      session.artifacts = { ...(session.artifacts || {}), ...Object.fromEntries(filteredEntries) }
+    }
+  }
+  if (typeof patch.totalTurns === 'number' && Number.isFinite(patch.totalTurns)) {
+    session.total_turns = patch.totalTurns
+  }
+  if (typeof patch.durationMs === 'number' && Number.isFinite(patch.durationMs)) {
+    session.duration_ms = patch.durationMs
+  }
+  if (patch.status) {
+    session.status = patch.status
+  }
+  mem.sessions.set(id, session)
 }
+
+export async function listSessions(): Promise<Session[]> {
+  const seen = new Map<string, RememberedSession>()
+  for (const session of mem.sessions.values()) {
+    seen.set(session.id, { ...session, turns: session.turns ? [...session.turns] : [] })
+  }
+
+  try {
+    const { blobs } = await listBlobs({ prefix: 'sessions/', limit: 2000 })
+    const manifests = blobs.filter((b) => /session-.+\.json$/.test(b.pathname))
+    for (const manifest of manifests) {
+      try {
+        const url = manifest.downloadUrl || manifest.url
+        const resp = await fetch(url)
+        if (!resp.ok) continue
+        const data = await resp.json()
+        const fallbackId = manifest.pathname.replace(/^sessions\//, '').split('/')[0] || data?.sessionId
+        const uploadedAt =
+          manifest.uploadedAt instanceof Date
+            ? manifest.uploadedAt.toISOString()
+            : typeof manifest.uploadedAt === 'string'
+            ? manifest.uploadedAt
+            : undefined
+        const storedId = rememberSessionManifest(data, fallbackId, uploadedAt, url)
+        const stored = storedId ? mem.sessions.get(storedId) : fallbackId ? mem.sessions.get(fallbackId) : undefined
+        if (stored) {
+          seen.set(stored.id, { ...stored, turns: stored.turns ? [...stored.turns] : [] })
+          continue
+        }
+        const derived = buildSessionFromManifest(data, fallbackId, uploadedAt)
+        if (derived) {
+          seen.set(derived.id, derived)
+        }
+      } catch (err) {
+        console.warn('Failed to parse session manifest', err)
+      }
+    }
+  } catch (err) {
+    console.warn('Failed to list session manifests', err)
+  }
+
+  return Array.from(seen.values()).sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+}
+
 export async function getSession(id: string): Promise<Session | undefined> {
-  const memSession = mem.sessions.get(id)
-  if (memSession) return memSession
+  const inMemory = mem.sessions.get(id)
+  if (inMemory) return inMemory
 
-  const stored = await fetchStoredSession(id)
-  if (!stored) return undefined
+  const manifest = await fetchSessionManifest(id)
+  if (manifest) {
+    const storedId = rememberSessionManifest(manifest.data, manifest.id, manifest.uploadedAt, manifest.url)
+    const stored = storedId ? mem.sessions.get(storedId) : mem.sessions.get(manifest.id)
+    if (stored) return stored
+    const derived = buildSessionFromManifest(manifest.data, manifest.id, manifest.uploadedAt)
+    if (derived) return derived
+  }
 
-  const turns: Turn[] = []
-  for (const entry of stored.turns.sort((a, b) => a.turn - b.turn)) {
-    const pad = String(entry.turn).padStart(4, '0')
-    turns.push({
-      id: `user-${pad}`,
-      role: 'user',
-      text: entry.transcript || '',
-      audio_blob_url: entry.audio || undefined,
-    })
-    if (entry.assistantReply) {
-      turns.push({
-        id: `assistant-${pad}`,
-        role: 'assistant',
-        text: entry.assistantReply,
-      })
+  return undefined
+}
+
+async function fetchSessionManifest(sessionId: string): Promise<ManifestLookup | null> {
+  try {
+    const { blobs } = await listBlobs({ prefix: `sessions/${sessionId}/`, limit: 25 })
+    const manifest = blobs.find((b) => /session-.+\.json$/.test(b.pathname))
+    if (!manifest) return null
+    const url = manifest.downloadUrl || manifest.url
+    const resp = await fetch(url)
+    if (!resp.ok) return null
+    const data = await resp.json()
+    return {
+      id: (typeof data?.sessionId === 'string' && data.sessionId) || sessionId,
+      uploadedAt:
+        manifest.uploadedAt instanceof Date
+          ? manifest.uploadedAt.toISOString()
+          : typeof manifest.uploadedAt === 'string'
+          ? manifest.uploadedAt
+          : undefined,
+      url,
+      data,
+    }
+  } catch (err) {
+    console.warn('Failed to fetch session manifest', err)
+    return null
+  }
+}
+
+export function rememberSessionManifest(
+  manifest: any,
+  fallbackId?: string,
+  fallbackCreatedAt?: string,
+  manifestUrl?: string,
+): string | undefined {
+  const derived = buildSessionFromManifest(manifest, fallbackId, fallbackCreatedAt)
+  if (!derived) return
+  if (manifestUrl) {
+    derived.artifacts = {
+      ...(derived.artifacts || {}),
+      session_manifest: manifestUrl,
+      manifest: manifestUrl,
+    }
+  }
+  mem.sessions.set(derived.id, {
+    ...derived,
+    turns: derived.turns ? [...derived.turns] : [],
+  })
+  return derived.id
+}
+
+export function buildSessionFromManifest(
+  data: any,
+  fallbackId?: string,
+  fallbackCreatedAt?: string,
+): RememberedSession | undefined {
+  if (!data || typeof data !== 'object') return undefined
+  const sessionId = typeof data.sessionId === 'string' ? data.sessionId : fallbackId
+  if (!sessionId) return undefined
+
+  const startedAt = typeof data.startedAt === 'string' ? data.startedAt : undefined
+  const endedAt = typeof data.endedAt === 'string' ? data.endedAt : undefined
+  const createdAt = startedAt || endedAt || fallbackCreatedAt || new Date().toISOString()
+
+  const artifactRecord: Record<string, string> = {}
+  if (data.artifacts && typeof data.artifacts === 'object') {
+    for (const [key, value] of Object.entries(data.artifacts as Record<string, unknown>)) {
+      if (typeof value === 'string') artifactRecord[key] = value
     }
   }
 
-  const createdAt = stored.startedAt || stored.endedAt || new Date().toISOString()
-  const artifacts: Record<string, string> = {}
-  if (stored.manifestUrl) artifacts.manifest = stored.manifestUrl
+  const turnEntries = Array.isArray(data.turns) ? data.turns : []
+  const turns: Turn[] = []
+  let highestTurnNumber = 0
+  for (const entry of turnEntries) {
+    if (!entry || typeof entry !== 'object') continue
+    const turnNumber = Number((entry as any).turn) || highestTurnNumber + 1
+    if (turnNumber > highestTurnNumber) highestTurnNumber = turnNumber
+    const transcript = typeof (entry as any).transcript === 'string' ? (entry as any).transcript : ''
+    const audio =
+      typeof (entry as any).audio === 'string'
+        ? (entry as any).audio
+        : typeof (entry as any).userAudioUrl === 'string'
+        ? (entry as any).userAudioUrl
+        : undefined
+    if (transcript) {
+      turns.push({ id: `user-${turnNumber}`, role: 'user', text: transcript, audio_blob_url: audio })
+    }
+    const assistantReply = extractAssistantReply(entry)
+    if (assistantReply) {
+      turns.push({ id: `assistant-${turnNumber}`, role: 'assistant', text: assistantReply })
+    }
+  }
 
-  return {
-    id: stored.sessionId,
+  const totals = typeof data.totals === 'object' && data.totals ? (data.totals as any) : {}
+  const totalTurns = Number(totals.turns) || highestTurnNumber || Math.ceil(turns.length / 2)
+  const durationMs = Number(totals.durationMs) || 0
+
+  const session: RememberedSession = {
+    id: sessionId,
     created_at: createdAt,
-    email_to: '',
+    title: typeof data.title === 'string' ? data.title : undefined,
+    email_to: typeof data.email === 'string' ? data.email : process.env.DEFAULT_NOTIFY_EMAIL || '',
     status: 'completed',
-    duration_ms: stored.totalDurationMs,
-    total_turns: turns.length,
-    artifacts: Object.keys(artifacts).length ? artifacts : undefined,
+    duration_ms: durationMs,
+    total_turns: totalTurns,
+    artifacts: Object.keys(artifactRecord).length ? artifactRecord : undefined,
     turns,
   }
+
+  if (typeof data.status === 'string') {
+    if (data.status === 'emailed' || data.status === 'in_progress' || data.status === 'error') {
+      session.status = data.status
+    }
+  }
+
+  return session
+}
+
+function extractAssistantReply(entry: any): string {
+  if (!entry || typeof entry !== 'object') return ''
+  const candidates = [entry.assistantReply, entry.reply, entry.assistant?.reply, entry.assistant?.text]
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.trim().length) return value
+  }
+  return ''
 }

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -1,10 +1,21 @@
 import { list } from '@vercel/blob'
+import { getBlobToken } from './blob'
 
-type RawTurnBlob = { url: string; uploadedAt: string; name: string }
+type RawTurnBlob = { url: string; downloadUrl?: string; uploadedAt: string; name: string }
+
+type StoredArtifacts = {
+  manifest?: string | null
+  transcript_txt?: string | null
+  transcript_json?: string | null
+  session_manifest?: string | null
+  session_audio?: string | null
+}
 
 export type StoredTurn = {
   turn: number
   audio: string | null
+  assistantAudio: string | null
+  assistantAudioDurationMs: number
   manifest: string
   transcript: string
   assistantReply: string
@@ -20,14 +31,30 @@ export type StoredSession = {
   totalTurns: number
   totalDurationMs: number
   turns: StoredTurn[]
+  artifacts?: StoredArtifacts
 }
 
-type SessionEntry = StoredSession & { turnBlobs: RawTurnBlob[]; latestUploadedAt: string }
+type SessionEntry = StoredSession & {
+  turnBlobs: RawTurnBlob[]
+  latestUploadedAt: string
+  artifacts: StoredArtifacts
+}
 
 function ensureToken() {
-  const token = process.env.VERCEL_BLOB_READ_WRITE_TOKEN
-  if (!token) throw new Error('Missing VERCEL_BLOB_READ_WRITE_TOKEN')
+  const token = getBlobToken()
+  if (!token) throw new Error('Missing VERCEL_BLOB_READ_WRITE_TOKEN or BLOB_READ_WRITE_TOKEN')
   return token
+}
+
+function normalizeUploadedAt(uploadedAt: unknown): string {
+  if (!uploadedAt) return ''
+  if (typeof uploadedAt === 'string') return uploadedAt
+  if (uploadedAt instanceof Date) return uploadedAt.toISOString()
+  try {
+    return new Date(uploadedAt as string).toISOString()
+  } catch {
+    return String(uploadedAt)
+  }
 }
 
 async function enrich(entry: SessionEntry): Promise<StoredSession> {
@@ -37,7 +64,7 @@ async function enrich(entry: SessionEntry): Promise<StoredSession> {
 
   for (const turn of entry.turnBlobs) {
     try {
-      const resp = await fetch(turn.url)
+      const resp = await fetch(turn.downloadUrl || turn.url)
       const json = await resp.json()
       const turnNumber = Number(json.turn) || turns.length + 1
       const created = json.createdAt || turn.uploadedAt || null
@@ -50,7 +77,9 @@ async function enrich(entry: SessionEntry): Promise<StoredSession> {
       turns.push({
         turn: turnNumber,
         audio: typeof json.userAudioUrl === 'string' ? json.userAudioUrl : null,
-        manifest: turn.url,
+        assistantAudio: typeof json.assistantAudioUrl === 'string' ? json.assistantAudioUrl : null,
+        assistantAudioDurationMs: Number(json.assistantAudioDurationMs) || 0,
+        manifest: turn.downloadUrl || turn.url,
         transcript: typeof json.transcript === 'string' ? json.transcript : '',
         assistantReply: typeof json.assistantReply === 'string' ? json.assistantReply : '',
         durationMs: duration,
@@ -75,6 +104,12 @@ async function enrich(entry: SessionEntry): Promise<StoredSession> {
       if (Number.isFinite(totalTurnsFromManifest)) {
         entry.totalTurns = totalTurnsFromManifest as number
       }
+      if (!entry.artifacts.transcript_txt && json?.artifacts?.transcript_txt) {
+        entry.artifacts.transcript_txt = json.artifacts.transcript_txt
+      }
+      if (!entry.artifacts.transcript_json && json?.artifacts?.transcript_json) {
+        entry.artifacts.transcript_json = json.artifacts.transcript_json
+      }
     } catch {
       // ignore manifest parse errors
     }
@@ -91,6 +126,13 @@ async function enrich(entry: SessionEntry): Promise<StoredSession> {
     totalTurns: entry.totalTurns,
     totalDurationMs: entry.totalDurationMs,
     turns,
+    artifacts: {
+      manifest: entry.manifestUrl,
+      transcript_txt: entry.artifacts.transcript_txt ?? null,
+      transcript_json: entry.artifacts.transcript_json ?? null,
+      session_audio: entry.artifacts.session_audio ?? null,
+      session_manifest: entry.artifacts.session_manifest ?? null,
+    },
   }
 }
 
@@ -114,20 +156,37 @@ function buildEntries(blobs: Awaited<ReturnType<typeof list>>['blobs']) {
         turns: [],
         turnBlobs: [],
         latestUploadedAt: '0',
+        artifacts: {},
       } as SessionEntry)
 
     if (/^turn-\d+\.json$/.test(name)) {
-      existing.turnBlobs.push({ url: blob.url, uploadedAt: blob.uploadedAt, name })
-      if (!existing.latestUploadedAt || blob.uploadedAt > existing.latestUploadedAt) {
-        existing.latestUploadedAt = blob.uploadedAt
+      const uploadedAt = normalizeUploadedAt(blob.uploadedAt)
+      existing.turnBlobs.push({ url: blob.url, downloadUrl: blob.downloadUrl, uploadedAt, name })
+      if (!existing.latestUploadedAt || uploadedAt > existing.latestUploadedAt) {
+        existing.latestUploadedAt = uploadedAt
       }
     }
 
     if (/^session-.+\.json$/.test(name)) {
-      existing.manifestUrl = blob.url
-      if (!existing.latestUploadedAt || blob.uploadedAt > existing.latestUploadedAt) {
-        existing.latestUploadedAt = blob.uploadedAt
+      const manifestUrl = blob.downloadUrl || blob.url
+      existing.manifestUrl = manifestUrl
+      existing.artifacts.session_manifest = manifestUrl
+      const uploadedAt = normalizeUploadedAt(blob.uploadedAt)
+      if (!existing.latestUploadedAt || uploadedAt > existing.latestUploadedAt) {
+        existing.latestUploadedAt = uploadedAt
       }
+    }
+
+    if (/^transcript-.+\.txt$/.test(name)) {
+      existing.artifacts.transcript_txt = blob.downloadUrl || blob.url
+    }
+
+    if (/^transcript-.+\.json$/.test(name)) {
+      existing.artifacts.transcript_json = blob.downloadUrl || blob.url
+    }
+
+    if (/^session-audio\./.test(name)) {
+      existing.artifacts.session_audio = blob.downloadUrl || blob.url
     }
 
     sessions.set(id, existing)

--- a/lib/openaiTts.ts
+++ b/lib/openaiTts.ts
@@ -43,7 +43,7 @@ export async function synthesizeSpeechWithOpenAi({
     model,
     voice,
     input: text,
-    format,
+    response_format: format,
     speed,
   })
 

--- a/lib/session-recorder.ts
+++ b/lib/session-recorder.ts
@@ -1,0 +1,168 @@
+export type SessionRecordingResult = {
+  blob: Blob
+  mimeType: string
+  durationMs: number
+}
+
+type PlaybackResult = {
+  durationMs: number
+}
+
+const SUPPORTED_MIME_TYPES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/ogg;codecs=opus',
+  'audio/ogg',
+]
+
+export class SessionRecorder {
+  private audioCtx: AudioContext | null = null
+  private destination: MediaStreamAudioDestinationNode | null = null
+  private micStream: MediaStream | null = null
+  private micSource: MediaStreamAudioSourceNode | null = null
+  private recorder: MediaRecorder | null = null
+  private chunks: Blob[] = []
+  private mimeType: string = 'audio/webm'
+  private startedAt = 0
+
+  async start(): Promise<void> {
+    if (typeof window === 'undefined') throw new Error('SessionRecorder unavailable')
+    if (this.recorder && this.recorder.state === 'recording') return
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    const ctx = new AudioContext()
+    await ctx.resume()
+    const destination = ctx.createMediaStreamDestination()
+    const micSource = ctx.createMediaStreamSource(stream)
+    micSource.connect(destination)
+
+    const supportedMime = SUPPORTED_MIME_TYPES.find((candidate) => {
+      try {
+        return MediaRecorder.isTypeSupported(candidate)
+      } catch {
+        return false
+      }
+    })
+
+    const recorder = supportedMime
+      ? new MediaRecorder(destination.stream, { mimeType: supportedMime })
+      : new MediaRecorder(destination.stream)
+
+    this.audioCtx = ctx
+    this.destination = destination
+    this.micStream = stream
+    this.micSource = micSource
+    this.recorder = recorder
+    this.mimeType = supportedMime || recorder.mimeType || 'audio/webm'
+    this.chunks = []
+    this.startedAt = performance.now()
+
+    recorder.ondataavailable = (event) => {
+      if (event.data && event.data.size) {
+        this.chunks.push(event.data)
+      }
+    }
+
+    recorder.start()
+  }
+
+  async playAssistantBase64(base64: string, _mime?: string): Promise<PlaybackResult> {
+    if (!this.audioCtx || !this.destination) throw new Error('Recorder not started')
+    await this.audioCtx.resume()
+    const arrayBuffer = SessionRecorder.base64ToArrayBuffer(base64)
+    const audioBuffer = await this.audioCtx.decodeAudioData(arrayBuffer.slice(0))
+    return this.playAudioBuffer(audioBuffer)
+  }
+
+  async stop(): Promise<SessionRecordingResult> {
+    if (!this.recorder) throw new Error('Recorder not started')
+
+    if (this.recorder.state === 'inactive') {
+      return { blob: new Blob([], { type: this.mimeType }), mimeType: this.mimeType, durationMs: 0 }
+    }
+
+    return await new Promise<SessionRecordingResult>((resolve) => {
+      const recorder = this.recorder as MediaRecorder
+      recorder.onstop = () => {
+        const blob = new Blob(this.chunks, { type: this.mimeType })
+        const durationMs = this.startedAt ? Math.max(0, Math.round(performance.now() - this.startedAt)) : 0
+        this.cleanup()
+        resolve({ blob, mimeType: this.mimeType, durationMs })
+      }
+      try {
+        recorder.stop()
+      } catch {
+        this.cleanup()
+        resolve({ blob: new Blob([], { type: this.mimeType }), mimeType: this.mimeType, durationMs: 0 })
+      }
+    })
+  }
+
+  cancel() {
+    if (this.recorder && this.recorder.state !== 'inactive') {
+      try {
+        this.recorder.stop()
+      } catch {}
+    }
+    this.cleanup()
+  }
+
+  private playAudioBuffer(audioBuffer: AudioBuffer): Promise<PlaybackResult> {
+    if (!this.audioCtx || !this.destination) throw new Error('Recorder not started')
+    const source = this.audioCtx.createBufferSource()
+    source.buffer = audioBuffer
+    source.connect(this.audioCtx.destination)
+    source.connect(this.destination)
+    const durationMs = Math.round(audioBuffer.duration * 1000)
+    return new Promise<PlaybackResult>((resolve, reject) => {
+      source.onended = () => resolve({ durationMs })
+      try {
+        source.start()
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error('play_failed'))
+      }
+    })
+  }
+
+  private cleanup() {
+    try {
+      if (this.micSource && this.destination) {
+        this.micSource.disconnect(this.destination)
+      }
+    } catch {}
+    if (this.micStream) {
+      try {
+        this.micStream.getTracks().forEach((track) => track.stop())
+      } catch {}
+    }
+    if (this.audioCtx) {
+      try {
+        this.audioCtx.close()
+      } catch {}
+    }
+    this.audioCtx = null
+    this.destination = null
+    this.micStream = null
+    this.micSource = null
+    this.recorder = null
+    this.chunks = []
+    this.startedAt = 0
+  }
+
+  private static base64ToArrayBuffer(base64: string): ArrayBuffer {
+    if (typeof atob === 'undefined') {
+      throw new Error('Base64 decoding unavailable in this environment')
+    }
+    const binary = atob(base64)
+    const len = binary.length
+    const bytes = new Uint8Array(len)
+    for (let i = 0; i < len; i += 1) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes.buffer
+  }
+}
+
+export function createSessionRecorder() {
+  return new SessionRecorder()
+}

--- a/tests/blob.test.ts
+++ b/tests/blob.test.ts
@@ -2,13 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 afterEach(() => {
   delete process.env.VERCEL_BLOB_READ_WRITE_TOKEN
+  delete process.env.BLOB_READ_WRITE_TOKEN
   vi.resetModules()
   vi.restoreAllMocks()
 })
 
 describe('putBlobFromBuffer', () => {
   it('uses public access when uploading with a token', async () => {
-    process.env.VERCEL_BLOB_READ_WRITE_TOKEN = 'test-token'
+    process.env.BLOB_READ_WRITE_TOKEN = 'test-token'
     const putSpy = vi.fn(async () => ({
       url: 'https://blob.test/resource',
       downloadUrl: 'https://blob.test/resource?download=1',
@@ -40,5 +41,24 @@ describe('putBlobFromBuffer', () => {
     const result = await putBlobFromBuffer('path/file.txt', Buffer.from('hi'), 'text/plain')
 
     expect(result.url.startsWith('data:text/plain;base64,')).toBe(true)
+    expect(result.downloadUrl).toBe(result.url)
+  })
+})
+
+describe('listBlobs', () => {
+  it('returns fallback entries when no token is present', async () => {
+    vi.doMock('@vercel/blob', () => ({
+      put: vi.fn(),
+      list: vi.fn(),
+    }))
+    const { putBlobFromBuffer, listBlobs, clearFallbackBlobs } = await import('../lib/blob')
+    clearFallbackBlobs()
+
+    await putBlobFromBuffer('sessions/test/item.json', Buffer.from('{}'), 'application/json')
+    const result = await listBlobs({ prefix: 'sessions/test/' })
+
+    expect(result.blobs).toHaveLength(1)
+    expect(result.blobs[0].pathname).toBe('sessions/test/item.json')
+    expect(result.blobs[0].downloadUrl).toEqual(result.blobs[0].url)
   })
 })

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -60,4 +60,20 @@ describe('finalizeSession', () => {
     const stored = await data.getSession(session.id)
     expect(stored?.status).toBe('error')
   })
+
+  it('persists session audio artifacts when provided', async () => {
+    const data = await import('../lib/data')
+    sendEmailMock.mockResolvedValue({ skipped: true })
+    const session = await data.createSession({ email_to: 'user@example.com' })
+
+    await data.appendTurn(session.id, { role: 'assistant', text: 'hello again' })
+
+    await data.finalizeSession(session.id, {
+      clientDurationMs: 1234,
+      sessionAudioUrl: 'https://blob.test/sessions/123/session-audio.webm',
+    })
+
+    const stored = await data.getSession(session.id)
+    expect(stored?.artifacts?.session_audio).toBe('https://blob.test/sessions/123/session-audio.webm')
+  })
 })


### PR DESCRIPTION
## Summary
- ensure the finalize workflow waits for the blob-backed endpoint before calling the legacy in-memory finalize
- log response bodies safely and treat stateless "session not found" replies as optional instead of failing the client

## Testing
- CI=1 npm run build
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb006d882c832aa61e50068bed28f6