### PR TITLE
Improve turn loop stability and TTS handling

### DIFF
--- a/app/api/finalize-session/route.ts
+++ b/app/api/finalize-session/route.ts
@@ -38,6 +38,16 @@ export async function POST(req: NextRequest) {
     const body = await req.json()
     const { sessionId, email, sessionAudioUrl, sessionAudioDurationMs } = schema.parse(body)
 
+    const envBaseUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      process.env.NEXT_PUBLIC_SITE_URL ||
+      process.env.APP_URL ||
+      process.env.SITE_URL ||
+      ''
+    const requestOrigin = req.nextUrl?.origin || ''
+    const baseUrl = (requestOrigin || envBaseUrl).replace(/\/$/, '')
+    const sessionPageUrl = baseUrl ? `${baseUrl}/session/${sessionId}` : null
+
     const token = getBlobToken()
 
     let turnBlobs: Awaited<ReturnType<typeof listBlobs>>['blobs'] = []
@@ -329,6 +339,7 @@ export async function POST(req: NextRequest) {
         .join('\n\n')
       const bodyParts = [
         'Your session is finalized. Here are your links.',
+        sessionPageUrl ? `Session history: ${sessionPageUrl}` : null,
         summarizeLink(manifestUrl, 'Session manifest'),
         summarizeLink(transcriptTxtUrl, 'Transcript (txt)'),
         summarizeLink(transcriptJsonUrl, 'Transcript (json)'),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,32 @@ import './globals.css'
 import React from 'react'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const commitSha =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? ''
+  const commitMessage =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_MESSAGE ?? process.env.VERCEL_GIT_COMMIT_MESSAGE ?? 'local changes'
+  const commitTimestamp =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_TIMESTAMP ?? process.env.VERCEL_GIT_COMMIT_TIMESTAMP ?? null
+  const repoOwner =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER ?? process.env.VERCEL_GIT_REPO_OWNER ?? ''
+  const repoSlug =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG ?? process.env.VERCEL_GIT_REPO_SLUG ?? ''
+
+  const shortSha = commitSha ? commitSha.slice(0, 7) : 'local'
+  const commitUrl = commitSha && repoOwner && repoSlug ? `https://github.com/${repoOwner}/${repoSlug}/commit/${commitSha}` : null
+
+  let formattedTime = 'just now (Eastern Time)'
+  if (commitTimestamp) {
+    const parsed = new Date(commitTimestamp)
+    if (!Number.isNaN(parsed.valueOf())) {
+      formattedTime = `${new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/New_York',
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(parsed)} Eastern Time`
+    }
+  }
+
   return (
     <html lang="en">
       <body className="min-h-screen">
@@ -16,7 +42,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </nav>
           </header>
           {children}
-          <footer className="mt-10 text-xs opacity-70">v1.3.1 — continuity-first build.</footer>
+          <footer className="mt-10 text-xs opacity-70">
+            {commitUrl ? (
+              <a href={commitUrl} className="underline">
+                {shortSha} — {commitMessage}
+              </a>
+            ) : (
+              <span>
+                {shortSha} — {commitMessage}
+              </span>
+            )}{' '}
+            · {formattedTime}
+          </footer>
         </div>
       </body>
     </html>

--- a/lib/audio-bridge.ts
+++ b/lib/audio-bridge.ts
@@ -3,6 +3,16 @@
 
 export type RecordResult = { blob: Blob; durationMs: number }
 
+export type RecordOptions = {
+  baseline: number
+  minDurationMs?: number
+  maxDurationMs?: number
+  silenceMs?: number
+  graceMs?: number
+  shouldForceStop?: () => boolean
+  maxWaitMs?: number
+}
+
 async function getModule(): Promise<any> {
   // Dynamic import so it only loads client-side
   try {
@@ -21,7 +31,7 @@ export async function calibrateRMS(seconds = 2.0): Promise<number> {
   return typeof mod.calibrateRMS === 'function' ? await mod.calibrateRMS(seconds) : 0
 }
 
-export async function recordUntilSilence(args: any): Promise<RecordResult> {
+export async function recordUntilSilence(args: RecordOptions): Promise<RecordResult> {
   const mod = await getModule()
   if (typeof mod.recordUntilSilence !== 'function') throw new Error('Audio recording unavailable')
   return await mod.recordUntilSilence(args)


### PR DESCRIPTION
## Summary
- include the chosen voice in the TTS API response so the client can log which synthetic voice was used
- harden the home page turn loop with explicit abort controls, richer logging, and playback cancellation so finish requests interrupt immediately
- extend the session recorder with stoppable playback so assistant audio can be halted during finalization or user interrupts

## Testing
- _Not run (per instructions)_

------
https://chatgpt.com/codex/tasks/task_e_68cd6841af74832a95ad3a8d5cfdc21b