### PR TITLE
Enhance history titles and enlarge home status visuals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from 'next/server'
 import { listSessions } from '@/lib/data'
 import { fetchStoredSessions } from '@/lib/history'
+import { generateSessionTitle, SummarizableTurn } from '@/lib/session-title'
 
 export async function GET() {
   const items = await listSessions()
   const rows = items.map(s => ({
     id: s.id,
     created_at: s.created_at,
-    title: s.title || null,
+    title:
+      s.title ||
+      generateSessionTitle(s.turns, {
+        fallback: `Session on ${new Date(s.created_at).toLocaleDateString()}`,
+      }) ||
+      null,
     status: s.status,
     total_turns: s.total_turns,
     artifacts: {
@@ -26,10 +32,23 @@ export async function GET() {
   const { items: stored } = await fetchStoredSessions({ limit: 50 })
   for (const session of stored) {
     if (rows.some(r => r.id === session.sessionId)) continue
+    const summarizableTurns: SummarizableTurn[] = (session.turns || []).flatMap((turn) =>
+      [
+        { role: 'user' as const, text: turn.transcript },
+        turn.assistantReply ? { role: 'assistant' as const, text: turn.assistantReply } : null,
+      ].filter(Boolean) as SummarizableTurn[],
+    )
+
     rows.push({
       id: session.sessionId,
       created_at: session.startedAt || session.endedAt || new Date().toISOString(),
-      title: null,
+      title:
+        generateSessionTitle(summarizableTurns, {
+          fallback: `Session on ${
+            new Date(session.startedAt || session.endedAt || new Date().toISOString()).toLocaleDateString()
+          }`,
+        }) ||
+        null,
       status: 'completed',
       total_turns: session.totalTurns,
       artifacts: {
@@ -61,6 +80,13 @@ export async function GET() {
     const raw = (globalThis as any)?.localStorage?.getItem?.('demoHistory')
     if (raw) demo = JSON.parse(raw)
   } catch {}
-  const demoRows = (demo||[]).map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{ transcript_txt: null, transcript_json: null } }))
+  const demoRows = (demo || []).map((d: any) => ({
+    id: d.id,
+    created_at: d.created_at,
+    title: typeof d.title === 'string' && d.title.length ? d.title : null,
+    status: 'completed',
+    total_turns: 1,
+    artifacts: { transcript_txt: null, transcript_json: null },
+  }))
   return NextResponse.json({ items: [...demoRows, ...rows] })
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,3 +7,37 @@ body { background: var(--bg); color: var(--fg); }
 button { @apply rounded-2xl px-4 py-2 font-medium; }
 textarea { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
 a { text-underline-offset: 2px; }
+
+@keyframes softPulse {
+  from {
+    transform: scale(0.96);
+    opacity: 0.8;
+  }
+  to {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+}
+
+.animate-soft-pulse {
+  animation: softPulse 3.5s ease-in-out infinite alternate;
+}
+
+@keyframes slowRipple {
+  0% {
+    transform: scale(1);
+    opacity: 0.35;
+  }
+  70% {
+    transform: scale(1.24);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1.34);
+    opacity: 0;
+  }
+}
+
+.animate-slow-ripple {
+  animation: slowRipple 4.5s ease-out infinite;
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -32,8 +32,15 @@ export default function HistoryPage() {
         try {
           const raw = localStorage.getItem('demoHistory')
           if (raw) {
-            const list = JSON.parse(raw) as { id:string, created_at:string }[]
-            demoRows = list.map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{} }))
+            const list = JSON.parse(raw) as { id: string; created_at: string; title?: string | null }[]
+            demoRows = list.map((d) => ({
+              id: d.id,
+              created_at: d.created_at,
+              title: typeof d.title === 'string' && d.title.length ? d.title : null,
+              status: 'completed',
+              total_turns: 1,
+              artifacts: {},
+            }))
           }
         } catch {}
         setRows([...(demoRows||[]), ...(serverRows||[])])
@@ -58,7 +65,9 @@ export default function HistoryPage() {
             <li key={s.id} className="bg-white/5 rounded p-3">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="font-medium">{s.title || 'Untitled session'}</div>
+                  <div className="font-medium">
+                    {s.title || `Session from ${new Date(s.created_at).toLocaleString()}`}
+                  </div>
                   <div className="text-xs opacity-70">{new Date(s.created_at).toLocaleString()}</div>
                   <div className="text-xs opacity-70">Turns: {s.total_turns} • Status: {s.status}</div>
                 </div>

--- a/lib/audio-bridge.ts
+++ b/lib/audio-bridge.ts
@@ -6,11 +6,9 @@ export type RecordResult = { blob: Blob; durationMs: number }
 async function getModule(): Promise<any> {
   // Dynamic import so it only loads client-side
   try {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return await import('../src/lib/audio.js')
   } catch {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return await import('../src/lib/audio')
   }

--- a/lib/session-title.ts
+++ b/lib/session-title.ts
@@ -1,0 +1,86 @@
+export type SummarizableTurn = {
+  role: 'user' | 'assistant'
+  text?: string | null
+}
+
+function splitIntoSentences(text: string): string[] {
+  const cleaned = text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()
+  if (!cleaned) return []
+  const sentences = cleaned
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.replace(/^['"“”]+|['"“”]+$/g, '').trim())
+    .filter(Boolean)
+  if (sentences.length) return sentences
+  return [cleaned]
+}
+
+function scoreSentence(sentence: string, role: SummarizableTurn['role']): number {
+  let score = 0
+  const length = sentence.length
+  if (length >= 12) score += Math.min(1.5, length / 80)
+  if (/[,:;]/.test(sentence)) score += 0.2
+  if (/(because|when|after|before|while|remember|recall|story|moment|detail)/i.test(sentence)) score += 0.6
+  if (/\b(I|We|My|Our|He|She|They)\b/.test(sentence)) score += 0.4
+  if (role === 'user') score += 1.1
+  else score += 0.4
+  return score
+}
+
+function finalizeSentence(sentence: string): string {
+  let result = sentence.replace(/\s+/g, ' ').trim()
+  if (!result) return ''
+  result = result.charAt(0).toUpperCase() + result.slice(1)
+  const limit = 120
+  if (result.length > limit) {
+    const truncated = result.slice(0, limit - 1)
+    const lastSpace = truncated.lastIndexOf(' ')
+    if (lastSpace > 40) {
+      result = truncated.slice(0, lastSpace) + '…'
+    } else {
+      result = truncated + '…'
+    }
+    return result
+  }
+  if (!/[.!?…]$/.test(result)) {
+    result += '.'
+  }
+  return result
+}
+
+export function generateSessionTitle(
+  turns: SummarizableTurn[] | undefined | null,
+  options: { fallback?: string } = {},
+): string | undefined {
+  const fallback = options.fallback
+  if (!turns || !turns.length) {
+    return fallback
+  }
+
+  const candidates: { sentence: string; score: number; role: SummarizableTurn['role'] }[] = []
+
+  for (const turn of turns) {
+    if (!turn || typeof turn.text !== 'string') continue
+    const trimmed = turn.text.replace(/\s+/g, ' ').trim()
+    if (!trimmed) continue
+    const sentences = splitIntoSentences(trimmed)
+    for (const sentence of sentences) {
+      const scored = scoreSentence(sentence, turn.role)
+      if (scored <= 0) continue
+      candidates.push({ sentence, score: scored, role: turn.role })
+    }
+  }
+
+  if (!candidates.length) {
+    return fallback
+  }
+
+  candidates.sort((a, b) => b.score - a.score)
+
+  const preferred = candidates.find((entry) => entry.role === 'user' && entry.sentence.split(' ').length >= 3)
+  const chosen = preferred || candidates[0]
+  const finalized = finalizeSentence(chosen.sentence)
+  if (finalized) {
+    return finalized
+  }
+  return fallback
+}

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -34,8 +34,11 @@ describe('finalizeSession', () => {
 
     expect(result.emailed).toBe(true)
     expect(result.emailStatus).toEqual({ ok: true, provider: 'resend' })
+    expect(result.session.title && result.session.title.length).toBeTruthy()
+    expect(result.session.title?.toLowerCase()).not.toContain('untitled')
     const stored = await data.getSession(session.id)
     expect(stored?.status).toBe('emailed')
+    expect(stored?.title && stored.title.length).toBeTruthy()
   })
 
   it('handles skipped email when no provider configured', async () => {
@@ -53,6 +56,7 @@ describe('finalizeSession', () => {
     expect(result.emailStatus).toEqual({ skipped: true })
     const stored = await data.getSession(session.id)
     expect(stored?.status).toBe('completed')
+    expect(stored?.title && stored.title.length).toBeTruthy()
   })
 
   it('flags failures from the email provider', async () => {
@@ -70,6 +74,7 @@ describe('finalizeSession', () => {
     expect(result.emailStatus).toEqual({ ok: false, provider: 'resend', error: 'bad' })
     const stored = await data.getSession(session.id)
     expect(stored?.status).toBe('error')
+    expect(stored?.title && stored.title.length).toBeTruthy()
     const foxes = listFoxes()
     expect(foxes.some((fox) => fox.id === 'theory-4-email-status-error')).toBe(true)
   })


### PR DESCRIPTION
## Summary
- generate descriptive session titles from transcripts and reuse them across history views
- redesign the home screen to spotlight the state indicator with larger animations and a smaller diagnostics log
- add lint configuration and supporting tests to ensure titles are always populated

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce184d8114832ab48e8e343add959b