### PR TITLE
Auto-start conversation with memory-aware intro

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -8,14 +8,16 @@ import {
 } from '@/lib/question-memory'
 import { detectCompletionIntent } from '@/lib/intents'
 
-const SYSTEM_PROMPT = `You are a warm, patient biographer helping an older adult remember their life.
+const SYSTEM_PROMPT = `You are a warm, curious biographer inspired by the professor and book the family mentioned, but you are not following a rigid script.
 You remember every conversation provided in the memory section below.
-Goals: guide a long conversation in short steps; never repeat or paraphrase the user's words. Carefully listen for instructions, questions, or corrections from the user and respond directly before offering a next prompt. Ask one short, specific, sensory-rich question (<= 20 words) only when the user is ready to keep going.
-If the user signals they are finished for now, set end_intent to true and close warmly without pushing another question.
-If the user asks you a question, give a thoughtful answer before deciding whether to follow with a gentle prompt.
-Keep silence handling patient; do not rush to speak if the user pauses briefly.
-Background noise is irrelevant - focus on spoken voice only.
-Do not repeat any question that appears in the memory section.
+Principles:
+- Follow the user's lead and respond directly to any instruction, question, or aside before you consider another prompt.
+- Be open to any topic the user brings up, gently weaving the discussion back toward the life-story themes when it feels natural.
+- Never repeat or paraphrase the user's own words, and do not repeat questions listed in the memory section.
+- If a reply is brief or uncertain, adapt by changing angles or suggesting a different avenue instead of insisting on the same question.
+- Ask at most one short, specific, sensory-rich question (<= 20 words) only when the user seems ready to keep going.
+- Keep silence handling patient; do not rush to speak if the user pauses briefly.
+- If the user signals they are finished for now, set end_intent to true and close warmly without pushing another question.
 Return a JSON object: {"reply":"...", "transcript":"...", "end_intent":true|false}.`
 
 function safeJsonParse(input: string | null | undefined) {
@@ -129,10 +131,12 @@ export async function POST(req: NextRequest) {
     const fallbackQuestion = pickFallbackQuestion(memory.askedQuestions, memory.detailForFallback)
     const fallbackSuggestion = softenQuestion(fallbackQuestion)
     const fallbackReply = memory.detailForFallback
-      ? `I remember you mentioned ${memory.detailForFallback}. I'm here when you're ready to add more or head in a new direction.${
+      ? `I remember you mentioned ${memory.detailForFallback}. We can stay with that or wander somewhere entirely new—whatever feels right to you.${
           fallbackSuggestion ? ` ${fallbackSuggestion}` : ''
         }`
-      : `I’m here with you. ${fallbackSuggestion || 'Share whatever feels right next, or let me know how I can help.'}`
+      : `I'm here with you and happy to talk about anything on your mind.${
+          fallbackSuggestion ? ` ${fallbackSuggestion}` : ' If you’d like a prompt, I can offer one whenever you choose.'
+        }`
 
     if (!process.env.GOOGLE_API_KEY) {
       return NextResponse.json<AskAudioResponse>({

--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getSessionMemorySnapshot } from '@/lib/data'
+import {
+  collectAskedQuestions,
+  findLatestUserDetails,
+  normalizeQuestion,
+  pickFallbackQuestion,
+} from '@/lib/question-memory'
 
 const SYSTEM_PROMPT = `You are a warm, patient biographer helping an older adult remember their life.
+You remember every conversation provided in the memory section below.
 Goals: guide a long conversation in short steps; never repeat or paraphrase the user's words; ask one short, specific, sensory-rich question (<= 20 words) that either (a) digs deeper on the last detail, (b) moves to a closely related facet (people, place, date), or (c) gracefully shifts to a new chapter if the user signals they wish to.
 Keep silence handling patient; do not rush to speak if the user pauses briefly.
 Background noise is irrelevant - focus on spoken voice only.
+Do not repeat any question that appears in the memory section.
 Return a JSON object: {"reply":"...", "transcript":"...", "end_intent":true|false}.`
 
 function safeJsonParse(input: string | null | undefined) {
@@ -19,6 +28,8 @@ type AskAudioBody = {
   audio?: string
   format?: string
   text?: string
+  sessionId?: string
+  turn?: number
 }
 
 type AskAudioResponse = {
@@ -29,25 +40,96 @@ type AskAudioResponse = {
   end_intent: boolean
 }
 
+type MemoryPrompt = {
+  historyText: string
+  questionText: string
+  recentConversation: string
+  askedQuestions: string[]
+  detailForFallback?: string
+}
+
+function buildMemoryPrompt(sessionId: string | undefined): MemoryPrompt {
+  if (!sessionId) {
+    return {
+      historyText: 'No session memory is available yet.',
+      questionText: 'No prior questions are on record.',
+      recentConversation: '',
+      askedQuestions: [],
+    }
+  }
+
+  const { current, sessions } = getSessionMemorySnapshot(sessionId)
+  const askedQuestions = collectAskedQuestions(sessions)
+  const detailForFallback = findLatestUserDetails(sessions, { limit: 1 })[0]
+
+  const historyLines: string[] = []
+  const priorSessions = sessions.filter((session) => session.id !== sessionId)
+  if (priorSessions.length) {
+    historyLines.push('Highlights from previous sessions:')
+    for (const session of priorSessions.slice(0, 4)) {
+      const title = session.title ? session.title : `Session from ${new Date(session.created_at).toLocaleDateString()}`
+      const recentDetail = findLatestUserDetails([session], { limit: 1 })[0]
+      historyLines.push(`- ${title}${recentDetail ? ` → ${recentDetail}` : ''}`)
+    }
+  }
+
+  const conversationLines: string[] = []
+  if (current && current.turns.length) {
+    conversationLines.push('Current session so far:')
+    for (const turn of current.turns.slice(-6)) {
+      const roleLabel = turn.role === 'assistant' ? 'You' : 'User'
+      conversationLines.push(`${roleLabel}: ${turn.text}`)
+    }
+  }
+
+  const uniqueQuestions: string[] = []
+  const seen = new Set<string>()
+  for (const question of askedQuestions) {
+    const normalized = normalizeQuestion(question)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    uniqueQuestions.push(question)
+    if (uniqueQuestions.length >= 20) break
+  }
+
+  const questionLines = uniqueQuestions.length
+    ? ['Avoid repeating these prior questions:', ...uniqueQuestions.map((question) => `- ${question}`)]
+    : ['No prior questions are on record.']
+
+  return {
+    historyText: historyLines.length ? historyLines.join('\n') : 'No previous transcript details are available yet.',
+    questionText: questionLines.join('\n'),
+    recentConversation: conversationLines.join('\n'),
+    askedQuestions,
+    detailForFallback,
+  }
+}
+
 export async function POST(req: NextRequest) {
   const url = new URL(req.url)
   const provider = url.searchParams.get('provider') || process.env.PROVIDER || 'google'
   try {
     const raw = await req.text().catch(() => '')
     const body: AskAudioBody = raw && raw.length ? safeJsonParse(raw) : {}
-    const { audio, format = 'webm', text } = body || {}
+    const { audio, format = 'webm', text, sessionId } = body || {}
+
+    const memory = buildMemoryPrompt(sessionId)
+    const fallbackQuestion = pickFallbackQuestion(memory.askedQuestions, memory.detailForFallback)
 
     if (!process.env.GOOGLE_API_KEY) {
       return NextResponse.json<AskAudioResponse>({
         ok: true,
         provider,
-        reply: 'Who was with you? Name one person and what they wore.',
+        reply: fallbackQuestion,
         transcript: text || '',
         end_intent: false,
       })
     }
 
-    const parts: any[] = [{ text: SYSTEM_PROMPT }]
+    const parts: any[] = [{ text: SYSTEM_PROMPT }, { text: memory.historyText }, { text: memory.questionText }]
+    if (memory.recentConversation) {
+      parts.push({ text: memory.recentConversation })
+    }
     if (audio) parts.push({ inlineData: { mimeType: `audio/${format}`, data: audio } })
     if (text) parts.push({ text })
     parts.push({ text: 'Return JSON: {"reply":"...","transcript":"...","end_intent":false}' })
@@ -59,31 +141,42 @@ export async function POST(req: NextRequest) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ contents: [{ role: 'user', parts }] }),
-      }
+      },
     )
     const json = await response.json().catch(() => ({}))
     const txt =
-      json?.candidates?.[0]?.content?.parts?.map((p: any) => p?.text || '').filter(Boolean).join('\n') || ''
+      json?.candidates?.[0]?.content?.parts?.map((part: any) => part?.text || '').filter(Boolean).join('\n') || ''
 
     const fallback: AskAudioResponse = {
       ok: true,
       provider: 'google',
-      reply: 'Tell me about the light there: morning sun, lamps, or shadows?',
+      reply: fallbackQuestion,
       transcript: '',
       end_intent: false,
     }
 
     try {
-      const cleaned = txt.trim().replace(/^```(json)?/, '').replace(/```$/, '')
+      const cleaned = txt.trim().replace(/^```(json)?/i, '').replace(/```$/i, '')
       const parsed = JSON.parse(cleaned)
+      let reply = parsed.reply || fallback.reply
+      if (reply) {
+        const normalized = normalizeQuestion(reply)
+        if (normalized && memory.askedQuestions.some((question) => normalizeQuestion(question) === normalized)) {
+          reply = fallbackQuestion
+        }
+      }
       return NextResponse.json({
         ok: true,
         provider: 'google',
-        reply: parsed.reply || fallback.reply,
-        transcript: parsed.transcript || fallback.transcript,
+        reply,
+        transcript: parsed.transcript || fallback.transcript || '',
         end_intent: Boolean(parsed.end_intent),
       })
     } catch {
+      const normalized = normalizeQuestion(txt)
+      if (normalized && memory.askedQuestions.some((question) => normalizeQuestion(question) === normalized)) {
+        return NextResponse.json(fallback)
+      }
       return NextResponse.json({ ...fallback, reply: txt || fallback.reply })
     }
   } catch (e) {

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { blobHealth } from '@/lib/blob'
 import { dbHealth } from '@/lib/data'
+import { areSummaryEmailsEnabled } from '@/lib/email'
 
 export async function GET() {
   const blob = await blobHealth()
@@ -9,6 +10,7 @@ export async function GET() {
     hasOpenAI: Boolean(process.env.OPENAI_API_KEY),
     hasBlobToken: Boolean(process.env.VERCEL_BLOB_READ_WRITE_TOKEN),
     hasResend: Boolean(process.env.RESEND_API_KEY),
+    emailsEnabled: areSummaryEmailsEnabled(),
     defaultEmail: process.env.DEFAULT_NOTIFY_EMAIL || 'a@sarva.co',
   }
   return NextResponse.json({ ok: true, env, blob, db })

--- a/app/api/history/[id]/route.ts
+++ b/app/api/history/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { deleteSession } from '@/lib/data'
+
+export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
+  const id = params?.id
+  if (!id) {
+    return NextResponse.json({ ok: false, deleted: false, reason: 'missing_id' }, { status: 400 })
+  }
+
+  const result = await deleteSession(id)
+  const status = result.ok ? 200 : 500
+  return NextResponse.json(result, { status })
+}

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from 'next/server'
 import { listSessions } from '@/lib/data'
 import { fetchStoredSessions } from '@/lib/history'
+import { generateSessionTitle, SummarizableTurn } from '@/lib/session-title'
 
 export async function GET() {
   const items = await listSessions()
   const rows = items.map(s => ({
     id: s.id,
     created_at: s.created_at,
-    title: s.title || null,
+    title:
+      s.title ||
+      generateSessionTitle(s.turns, {
+        fallback: `Session on ${new Date(s.created_at).toLocaleDateString()}`,
+      }) ||
+      null,
     status: s.status,
     total_turns: s.total_turns,
     artifacts: {
@@ -26,10 +32,23 @@ export async function GET() {
   const { items: stored } = await fetchStoredSessions({ limit: 50 })
   for (const session of stored) {
     if (rows.some(r => r.id === session.sessionId)) continue
+    const summarizableTurns: SummarizableTurn[] = (session.turns || []).flatMap((turn) =>
+      [
+        { role: 'user' as const, text: turn.transcript },
+        turn.assistantReply ? { role: 'assistant' as const, text: turn.assistantReply } : null,
+      ].filter(Boolean) as SummarizableTurn[],
+    )
+
     rows.push({
       id: session.sessionId,
       created_at: session.startedAt || session.endedAt || new Date().toISOString(),
-      title: null,
+      title:
+        generateSessionTitle(summarizableTurns, {
+          fallback: `Session on ${
+            new Date(session.startedAt || session.endedAt || new Date().toISOString()).toLocaleDateString()
+          }`,
+        }) ||
+        null,
       status: 'completed',
       total_turns: session.totalTurns,
       artifacts: {
@@ -61,6 +80,13 @@ export async function GET() {
     const raw = (globalThis as any)?.localStorage?.getItem?.('demoHistory')
     if (raw) demo = JSON.parse(raw)
   } catch {}
-  const demoRows = (demo||[]).map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{ transcript_txt: null, transcript_json: null } }))
+  const demoRows = (demo || []).map((d: any) => ({
+    id: d.id,
+    created_at: d.created_at,
+    title: typeof d.title === 'string' && d.title.length ? d.title : null,
+    status: 'completed',
+    total_turns: 1,
+    artifacts: { transcript_txt: null, transcript_json: null },
+  }))
   return NextResponse.json({ items: [...demoRows, ...rows] })
 }

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { listSessions } from '@/lib/data'
+import { listSessions, clearAllSessions } from '@/lib/data'
 import { fetchStoredSessions } from '@/lib/history'
 import { generateSessionTitle, SummarizableTurn } from '@/lib/session-title'
 
@@ -89,4 +89,9 @@ export async function GET() {
     artifacts: { transcript_txt: null, transcript_json: null },
   }))
   return NextResponse.json({ items: [...demoRows, ...rows] })
+}
+
+export async function DELETE() {
+  await clearAllSessions()
+  return NextResponse.json({ ok: true, items: [] })
 }

--- a/app/api/session/[id]/intro/route.ts
+++ b/app/api/session/[id]/intro/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSessionMemorySnapshot } from '@/lib/data'
+import { collectAskedQuestions, findLatestUserDetails, normalizeQuestion, pickFallbackQuestion } from '@/lib/question-memory'
+
+const INTRO_SYSTEM_PROMPT = `You are a warm, patient biographer and this is the very first message in a new recording session.
+Your goals:
+- Welcome the user back, clearly stating you remember everything they have shared across all past sessions.
+- Reference one or two concrete details or titles from the provided history when available.
+- Ask exactly one new, specific, sensory-rich question (<= 25 words) that has not been asked before.
+- The question must invite a short spoken response and avoid repeating previous questions verbatim.
+Return JSON: {"message":"<spoken message including welcome and question>","question":"<just the final question>"}.
+Keep the message under 120 words, warm, and conversational.`
+
+function formatList(items: string[]): string {
+  if (items.length <= 1) return items[0] || ''
+  if (items.length === 2) return `${items[0]} and ${items[1]}`
+  return `${items[0]}, ${items[1]}, and ${items[2]}`
+}
+
+function buildFallbackIntro(options: {
+  titles: string[]
+  details: string[]
+  question: string
+}): string {
+  const { titles, details, question } = options
+  const introPrefix = titles.length
+    ? `Welcome back. I remember everything you've shared, especially ${formatList(titles.slice(0, 3))}.`
+    : 'Welcome. I will remember everything you share with me.'
+  const reminder = details.length
+    ? `The last thing you told me was about ${details[0]}.`
+    : 'Thank you for trusting me with your stories.'
+  return `${introPrefix} ${reminder} ${question}`.trim()
+}
+
+function buildHistorySummary(
+  titles: string[],
+  details: string[],
+  askedQuestions: string[],
+): { historyText: string; questionText: string } {
+  const historyLines: string[] = []
+  if (titles.length) {
+    historyLines.push('Session titles remembered:')
+    for (const title of titles.slice(0, 5)) {
+      historyLines.push(`- ${title}`)
+    }
+  }
+  if (details.length) {
+    historyLines.push('Recent user details:')
+    for (const detail of details.slice(0, 5)) {
+      historyLines.push(`- ${detail}`)
+    }
+  }
+  const historyText = historyLines.join('\n') || 'No previous transcript details are available yet.'
+
+  const uniqueQuestions: string[] = []
+  const seen = new Set<string>()
+  for (const question of askedQuestions) {
+    const normalized = normalizeQuestion(question)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    uniqueQuestions.push(question)
+    if (uniqueQuestions.length >= 12) break
+  }
+
+  const questionLines = uniqueQuestions.length
+    ? ['Avoid repeating these prior questions:', ...uniqueQuestions.map((question) => `- ${question}`)]
+    : ['No prior questions are on record.']
+
+  return { historyText, questionText: questionLines.join('\n') }
+}
+
+export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  const sessionId = params.id
+  const { current, sessions } = getSessionMemorySnapshot(sessionId)
+  if (!current) {
+    return NextResponse.json({ ok: false, error: 'session_not_found' }, { status: 404 })
+  }
+
+  const previousSessions = sessions.filter((session) => session.id !== sessionId)
+  const titles = previousSessions
+    .map((session) => session.title)
+    .filter((title): title is string => Boolean(title && title.trim().length))
+    .slice(0, 5)
+  const details = findLatestUserDetails(sessions, { excludeSessionId: sessionId, limit: 3 })
+  const askedQuestions = collectAskedQuestions(sessions)
+  const fallbackQuestion = pickFallbackQuestion(askedQuestions, details[0])
+  const fallbackMessage = buildFallbackIntro({ titles, details, question: fallbackQuestion })
+
+  if (!process.env.GOOGLE_API_KEY) {
+    return NextResponse.json({ ok: true, message: fallbackMessage, fallback: true })
+  }
+
+  try {
+    const { historyText, questionText } = buildHistorySummary(titles, details, askedQuestions)
+    const parts: any[] = [
+      { text: INTRO_SYSTEM_PROMPT },
+      { text: historyText },
+      { text: questionText },
+    ]
+
+    const model = process.env.GOOGLE_MODEL || 'gemini-1.5-flash'
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GOOGLE_API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ role: 'user', parts }] }),
+      },
+    )
+
+    const json = await response.json().catch(() => ({}))
+    const txt =
+      json?.candidates?.[0]?.content?.parts?.map((part: any) => part?.text || '').filter(Boolean).join('\n') || ''
+
+    let message = ''
+    try {
+      const cleaned = txt.trim().replace(/^```(json)?/i, '').replace(/```$/i, '')
+      const parsed = JSON.parse(cleaned)
+      if (parsed && typeof parsed.message === 'string') {
+        message = parsed.message.trim()
+        if (parsed.question && typeof parsed.question === 'string') {
+          const normalized = normalizeQuestion(parsed.question)
+          if (normalized && askedQuestions.some((question) => normalizeQuestion(question) === normalized)) {
+            message = `${message} ${fallbackQuestion}`.trim()
+          }
+        }
+      }
+    } catch {
+      message = txt.trim()
+    }
+
+    if (!message || !message.includes('?')) {
+      message = `${message ? `${message} ` : ''}${fallbackQuestion}`.trim()
+    }
+
+    if (!message) {
+      return NextResponse.json({ ok: true, message: fallbackMessage, fallback: true })
+    }
+
+    return NextResponse.json({ ok: true, message, fallback: false })
+  } catch (error: any) {
+    const reason = typeof error?.message === 'string' ? error.message : 'intro_failed'
+    return NextResponse.json({ ok: true, message: fallbackMessage, fallback: true, reason })
+  }
+}

--- a/app/api/session/[id]/intro/route.ts
+++ b/app/api/session/[id]/intro/route.ts
@@ -2,12 +2,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getSessionMemorySnapshot } from '@/lib/data'
 import { collectAskedQuestions, findLatestUserDetails, normalizeQuestion, pickFallbackQuestion } from '@/lib/question-memory'
 
-const INTRO_SYSTEM_PROMPT = `You are a warm, patient biographer and this is the very first message in a new recording session.
-Your goals:
+const INTRO_SYSTEM_PROMPT = `You are a warm, curious biographer and this is the very first message in a new recording session.
+You are inspired by the professor and book the family mentioned, yet you are not following a rigid script.
+Goals:
 - Welcome the user back, clearly stating you remember everything they have shared across all past sessions.
-- Reference one or two concrete details or titles from the provided history when available.
+- Refer to one or two concrete details or titles from the provided history when available.
+- Offer an inviting, conversational setup that signals you're happy to follow the user's interests while gently guiding them toward the life-story themes.
 - Ask exactly one new, specific, sensory-rich question (<= 25 words) that has not been asked before.
-- The question must invite a short spoken response and avoid repeating previous questions verbatim.
+- The question must invite a short spoken response, adapt to the recent context, and avoid repeating previous questions verbatim.
 Return JSON: {"message":"<spoken message including welcome and question>","question":"<just the final question>"}.
 Keep the message under 120 words, warm, and conversational.`
 
@@ -29,7 +31,7 @@ function buildFallbackIntro(options: {
   const reminder = details.length
     ? `The last thing you told me was about ${details[0]}.`
     : 'Thank you for trusting me with your stories.'
-  return `${introPrefix} ${reminder} ${question}`.trim()
+  return `${introPrefix} ${reminder} I'm happy to follow wherever you'd like to go. ${question}`.trim()
 }
 
 function buildHistorySummary(

--- a/app/api/session/start/route.ts
+++ b/app/api/session/start/route.ts
@@ -1,14 +1,29 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { createSession } from '@/lib/data'
 
 export const runtime = 'nodejs'
 
-export async function POST() {
+export async function POST(req: NextRequest) {
+  let payload: any = {}
+  try {
+    const raw = await req.text()
+    if (raw && raw.trim().length) {
+      payload = JSON.parse(raw)
+    }
+  } catch {
+    payload = {}
+  }
+
+  const rawEmail = typeof payload?.email === 'string' ? payload.email.trim() : ''
+  const emailsEnabled = payload?.emailsEnabled !== false
+  const defaultEmail = process.env.DEFAULT_NOTIFY_EMAIL || 'a@sarva.co'
+  const targetEmail = emailsEnabled ? rawEmail || defaultEmail : ''
+
   try {
     const session = await createSession({
-      email_to: process.env.DEFAULT_NOTIFY_EMAIL || 'a@sarva.co',
+      email_to: targetEmail,
     })
-    return NextResponse.json({ id: session.id })
+    return NextResponse.json({ id: session.id, email: session.email_to, emailsEnabled: emailsEnabled })
   } catch (error: any) {
     return NextResponse.json(
       { ok: false, error: error?.message || 'session_start_failed' },

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,3 +7,37 @@ body { background: var(--bg); color: var(--fg); }
 button { @apply rounded-2xl px-4 py-2 font-medium; }
 textarea { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
 a { text-underline-offset: 2px; }
+
+@keyframes softPulse {
+  from {
+    transform: scale(0.96);
+    opacity: 0.8;
+  }
+  to {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+}
+
+.animate-soft-pulse {
+  animation: softPulse 3.5s ease-in-out infinite alternate;
+}
+
+@keyframes slowRipple {
+  0% {
+    transform: scale(1);
+    opacity: 0.35;
+  }
+  70% {
+    transform: scale(1.24);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1.34);
+    opacity: 0;
+  }
+}
+
+.animate-slow-ripple {
+  animation: slowRipple 4.5s ease-out infinite;
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -32,8 +32,15 @@ export default function HistoryPage() {
         try {
           const raw = localStorage.getItem('demoHistory')
           if (raw) {
-            const list = JSON.parse(raw) as { id:string, created_at:string }[]
-            demoRows = list.map(d => ({ id: d.id, created_at: d.created_at, title: 'Demo session', status:'completed', total_turns: 1, artifacts:{} }))
+            const list = JSON.parse(raw) as { id: string; created_at: string; title?: string | null }[]
+            demoRows = list.map((d) => ({
+              id: d.id,
+              created_at: d.created_at,
+              title: typeof d.title === 'string' && d.title.length ? d.title : null,
+              status: 'completed',
+              total_turns: 1,
+              artifacts: {},
+            }))
           }
         } catch {}
         setRows([...(demoRows||[]), ...(serverRows||[])])
@@ -58,7 +65,9 @@ export default function HistoryPage() {
             <li key={s.id} className="bg-white/5 rounded p-3">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="font-medium">{s.title || 'Untitled session'}</div>
+                  <div className="font-medium">
+                    {s.title || `Session from ${new Date(s.created_at).toLocaleString()}`}
+                  </div>
                   <div className="text-xs opacity-70">{new Date(s.created_at).toLocaleString()}</div>
                   <div className="text-xs opacity-70">Turns: {s.total_turns} • Status: {s.status}</div>
                 </div>

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -50,7 +50,7 @@ export default function HistoryPage() {
           if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0
           if (Number.isNaN(aTime)) return -1
           if (Number.isNaN(bTime)) return 1
-          return aTime - bTime
+          return bTime - aTime
         })
         setRows(combined)
       } catch {

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -43,7 +43,16 @@ export default function HistoryPage() {
             }))
           }
         } catch {}
-        setRows([...(demoRows||[]), ...(serverRows||[])])
+        const combined = [...(demoRows || []), ...(serverRows || [])]
+        combined.sort((a, b) => {
+          const aTime = new Date(a.created_at).getTime()
+          const bTime = new Date(b.created_at).getTime()
+          if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0
+          if (Number.isNaN(aTime)) return -1
+          if (Number.isNaN(bTime)) return 1
+          return aTime - bTime
+        })
+        setRows(combined)
       } catch {
         setRows([])
       }

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 type Row = {
   id: string
@@ -22,42 +22,88 @@ type Row = {
 
 export default function HistoryPage() {
   const [rows, setRows] = useState<Row[]>([])
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [clearingAll, setClearingAll] = useState(false)
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const api = await (await fetch('/api/history')).json()
+      const serverRows: Row[] = api?.items || []
+      let demoRows: Row[] = []
+      try {
+        const raw = localStorage.getItem('demoHistory')
+        if (raw) {
+          const list = JSON.parse(raw) as { id: string; created_at: string; title?: string | null }[]
+          demoRows = list.map((d) => ({
+            id: d.id,
+            created_at: d.created_at,
+            title: typeof d.title === 'string' && d.title.length ? d.title : null,
+            status: 'completed',
+            total_turns: 1,
+            artifacts: {},
+          }))
+        }
+      } catch {}
+      const combined = [...(demoRows || []), ...(serverRows || [])]
+      combined.sort((a, b) => {
+        const aTime = new Date(a.created_at).getTime()
+        const bTime = new Date(b.created_at).getTime()
+        if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0
+        if (Number.isNaN(aTime)) return -1
+        if (Number.isNaN(bTime)) return 1
+        return bTime - aTime
+      })
+      setRows(combined)
+    } catch {
+      setRows([])
+    }
+  }, [])
 
   useEffect(() => {
-    async function load() {
+    loadHistory()
+  }, [loadHistory])
+
+  const removeDemoEntry = useCallback((id: string) => {
+    try {
+      const raw = localStorage.getItem('demoHistory')
+      if (!raw) return
+      const list = JSON.parse(raw) as { id: string }[]
+      const filtered = list.filter((entry) => entry.id !== id)
+      if (filtered.length) {
+        localStorage.setItem('demoHistory', JSON.stringify(filtered))
+      } else {
+        localStorage.removeItem('demoHistory')
+      }
+    } catch {}
+  }, [])
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      setDeletingId(id)
       try {
-        const api = await (await fetch('/api/history')).json()
-        const serverRows: Row[] = api?.items || []
-        let demoRows: Row[] = []
-        try {
-          const raw = localStorage.getItem('demoHistory')
-          if (raw) {
-            const list = JSON.parse(raw) as { id: string; created_at: string; title?: string | null }[]
-            demoRows = list.map((d) => ({
-              id: d.id,
-              created_at: d.created_at,
-              title: typeof d.title === 'string' && d.title.length ? d.title : null,
-              status: 'completed',
-              total_turns: 1,
-              artifacts: {},
-            }))
-          }
-        } catch {}
-        const combined = [...(demoRows || []), ...(serverRows || [])]
-        combined.sort((a, b) => {
-          const aTime = new Date(a.created_at).getTime()
-          const bTime = new Date(b.created_at).getTime()
-          if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0
-          if (Number.isNaN(aTime)) return -1
-          if (Number.isNaN(bTime)) return 1
-          return bTime - aTime
-        })
-        setRows(combined)
-      } catch {
+        const resp = await fetch(`/api/history/${id}`, { method: 'DELETE' })
+        if (resp.ok) {
+          removeDemoEntry(id)
+          await loadHistory()
+        }
+      } finally {
+        setDeletingId(null)
+      }
+    },
+    [loadHistory, removeDemoEntry],
+  )
+
+  const handleClearAll = useCallback(async () => {
+    setClearingAll(true)
+    try {
+      const resp = await fetch('/api/history', { method: 'DELETE' })
+      if (resp.ok) {
+        localStorage.removeItem('demoHistory')
         setRows([])
       }
+    } finally {
+      setClearingAll(false)
     }
-    load()
   }, [])
 
   return (
@@ -72,7 +118,7 @@ export default function HistoryPage() {
         <ul className="space-y-3">
           {rows.map(s => (
             <li key={s.id} className="bg-white/5 rounded p-3">
-              <div className="flex items-center justify-between">
+              <div className="flex items-start justify-between gap-4">
                 <div>
                   <div className="font-medium">
                     {s.title || `Session from ${new Date(s.created_at).toLocaleString()}`}
@@ -80,7 +126,16 @@ export default function HistoryPage() {
                   <div className="text-xs opacity-70">{new Date(s.created_at).toLocaleString()}</div>
                   <div className="text-xs opacity-70">Turns: {s.total_turns} • Status: {s.status}</div>
                 </div>
-                <div className="flex flex-col gap-2 text-sm max-w-xl">
+                <div className="flex flex-col gap-2 text-sm max-w-xl items-end">
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(s.id)}
+                    disabled={deletingId === s.id || clearingAll}
+                    className="text-xs text-red-200/80 hover:text-red-100 disabled:opacity-50"
+                    aria-label="Delete session"
+                  >
+                    {deletingId === s.id ? 'Deleting…' : '🗑 Remove'}
+                  </button>
                   {(s.sessionAudioUrl || s.artifacts?.session_audio) && (
                     <audio
                       controls
@@ -135,6 +190,18 @@ export default function HistoryPage() {
             </li>
           ))}
         </ul>
+      )}
+      {rows.length > 0 && (
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            onClick={handleClearAll}
+            disabled={clearingAll || !!deletingId}
+            className="rounded border border-white/20 px-3 py-1 text-sm text-white/80 hover:border-white/40 hover:text-white disabled:opacity-50"
+          >
+            {clearingAll ? 'Clearing…' : 'Clear all history'}
+          </button>
+        </div>
       )}
     </main>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useInterviewMachine } from '@/lib/machine'
 import { calibrateRMS, recordUntilSilence, blobToBase64 } from '@/lib/audio-bridge'
 import { createSessionRecorder, SessionRecorder } from '@/lib/session-recorder'
+import { generateSessionTitle, SummarizableTurn } from '@/lib/session-title'
 
 const SESSION_STORAGE_KEY = 'sessionId'
 
@@ -92,7 +93,56 @@ const ensureSessionIdOnce = async (): Promise<SessionInitResult> => {
   return result
 }
 
-const OPENING = `Start testing greeting. Answer a question.`
+const INTRO_FALLBACK =
+  'Welcome back. I remember everything you have trusted me with. Tell me one new detail you would like to explore now.'
+
+const STATE_VISUALS: Record<
+  'idle' | 'recording' | 'thinking' | 'playing' | 'readyToContinue' | 'doneSuccess',
+  { icon: string; badge: string; title: string; description: string; gradient: string }
+> = {
+  idle: {
+    icon: '✨',
+    badge: 'Ready',
+    title: 'Ready to begin',
+    description: 'I’ll start the conversation and listen automatically. That glowing circle is all you need.',
+    gradient: 'from-sky-400/40 via-blue-500/30 to-indigo-500/40',
+  },
+  recording: {
+    icon: '🎤',
+    badge: 'Listening',
+    title: 'Listening',
+    description: 'I am capturing every detail you say. Speak naturally and take your time.',
+    gradient: 'from-emerald-400/40 via-lime-300/40 to-emerald-500/40',
+  },
+  thinking: {
+    icon: '🤔',
+    badge: 'Thinking',
+    title: 'Thinking',
+    description: 'Give me a brief moment while I make sense of what you shared.',
+    gradient: 'from-fuchsia-400/40 via-purple-500/40 to-indigo-600/40',
+  },
+  playing: {
+    icon: '💬',
+    badge: 'Speaking',
+    title: 'Speaking',
+    description: 'Here is what I heard and how I would respond to keep you going.',
+    gradient: 'from-amber-400/40 via-orange-500/40 to-amber-600/40',
+  },
+  readyToContinue: {
+    icon: '✨',
+    badge: 'Ready',
+    title: 'Ready for more',
+    description: 'I’m ready for whatever you want to share next—just start speaking.',
+    gradient: 'from-sky-400/40 via-cyan-400/40 to-blue-500/40',
+  },
+  doneSuccess: {
+    icon: '✅',
+    badge: 'Complete',
+    title: 'Session complete',
+    description: 'Review your links or start another memory when you feel inspired.',
+    gradient: 'from-slate-400/40 via-slate-500/40 to-slate-600/40',
+  },
+}
 
 type AssistantPlayback = {
   base64: string | null
@@ -117,6 +167,8 @@ export default function Home() {
   const finishRequestedRef = useRef(false)
   const sessionInitRef = useRef(false)
   const lastAnnouncedSessionIdRef = useRef<string | null>(null)
+  const conversationRef = useRef<SummarizableTurn[]>([])
+  const autoAdvanceTimeoutRef = useRef<number | null>(null)
 
   const MAX_TURNS = Number.POSITIVE_INFINITY
 
@@ -170,6 +222,10 @@ export default function Home() {
         recorderRef.current?.cancel()
       } catch {}
       recorderRef.current = null
+      if (typeof window !== 'undefined' && autoAdvanceTimeoutRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimeoutRef.current)
+      }
+      autoAdvanceTimeoutRef.current = null
     }
   }, [])
 
@@ -394,7 +450,11 @@ export default function Home() {
       try {
         const demo = JSON.parse(localStorage.getItem('demoHistory') || '[]')
         const stamp = new Date().toISOString()
-        demo.unshift({ id: sessionId, created_at: stamp })
+        const summaryTitle =
+          generateSessionTitle(conversationRef.current, {
+            fallback: `Session on ${new Date(stamp).toLocaleDateString()}`,
+          }) || null
+        demo.unshift({ id: sessionId, created_at: stamp, title: summaryTitle })
         localStorage.setItem('demoHistory', JSON.stringify(demo.slice(0, 50)))
       } catch {}
 
@@ -402,6 +462,7 @@ export default function Home() {
     } catch {
       pushLog('Finalize failed')
     } finally {
+      conversationRef.current = []
       finishRequestedRef.current = false
       setFinishRequested(false)
       setDisabledNext(false)
@@ -411,6 +472,10 @@ export default function Home() {
   const runTurnLoop = useCallback(async () => {
     if (!sessionId) return
     if (inTurnRef.current) return
+    if (typeof window !== 'undefined' && autoAdvanceTimeoutRef.current !== null) {
+      window.clearTimeout(autoAdvanceTimeoutRef.current)
+      autoAdvanceTimeoutRef.current = null
+    }
     inTurnRef.current = true
     setDisabledNext(true)
     try {
@@ -448,6 +513,13 @@ export default function Home() {
       const endIntent: boolean = askRes?.end_intent === true
       const endRegex =
         /(i[' ]?m done|i am done|stop for now|that's all|i[' ]?m finished|i am finished|we're done|let's stop|lets stop|all done|that's it|im done now|i[' ]?m good|i am done now)/i
+
+      if (transcript) {
+        conversationRef.current.push({ role: 'user', text: transcript })
+      }
+      if (reply) {
+        conversationRef.current.push({ role: 'assistant', text: reply })
+      }
 
       let assistantPlayback: AssistantPlayback = { base64: null, mime: 'audio/mpeg', durationMs: 0 }
       try {
@@ -507,6 +579,17 @@ export default function Home() {
         await finalizeNow()
       } else {
         setDisabledNext(false)
+        if (!finishRequestedRef.current && typeof window !== 'undefined') {
+          if (autoAdvanceTimeoutRef.current !== null) {
+            window.clearTimeout(autoAdvanceTimeoutRef.current)
+          }
+          autoAdvanceTimeoutRef.current = window.setTimeout(() => {
+            autoAdvanceTimeoutRef.current = null
+            if (!finishRequestedRef.current) {
+              runTurnLoop().catch(() => {})
+            }
+          }, 600)
+        }
       }
     } catch (e) {
       pushLog('There was a problem saving or asking. Check /api/health and env keys.')
@@ -517,23 +600,69 @@ export default function Home() {
 
   const startSession = useCallback(async () => {
     if (hasStarted) return
+    if (!sessionId) return
+    conversationRef.current = []
     setFinishRequested(false)
     finishRequestedRef.current = false
     setHasStarted(true)
     setDisabledNext(true)
+    let introMessage = ''
     try {
       try {
         await ensureSessionRecorder()
       } catch {
         pushLog('Session recorder unavailable; proceeding without combined audio')
       }
-      await playAssistantResponse(OPENING)
+
+      try {
+        const res = await fetch(`/api/session/${sessionId}/intro`, { method: 'POST' })
+        const json = await res.json().catch(() => null)
+        if (res.ok && typeof json?.message === 'string' && json.message.trim().length) {
+          introMessage = json.message.trim()
+        }
+      } catch (err) {
+        pushLog('Intro prompt unavailable; using fallback greeting')
+      }
+
+      if (!introMessage) {
+        introMessage = INTRO_FALLBACK
+      }
+
+      conversationRef.current.push({ role: 'assistant', text: introMessage })
+
+      try {
+        await fetch(`/api/session/${sessionId}/turn`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ role: 'assistant', text: introMessage }),
+        })
+      } catch {}
+
+      pushLog('Intro message ready → playing')
+      try {
+        await playAssistantResponse(introMessage)
+      } catch {
+        await playWithSpeechSynthesis(introMessage)
+      }
     } catch {
-      await playWithSpeechSynthesis(OPENING)
+      try {
+        await playWithSpeechSynthesis(INTRO_FALLBACK)
+      } catch {}
     } finally {
       setDisabledNext(false)
+      if (!finishRequestedRef.current && typeof window !== 'undefined') {
+        if (autoAdvanceTimeoutRef.current !== null) {
+          window.clearTimeout(autoAdvanceTimeoutRef.current)
+        }
+        autoAdvanceTimeoutRef.current = window.setTimeout(() => {
+          autoAdvanceTimeoutRef.current = null
+          if (!finishRequestedRef.current) {
+            runTurnLoop().catch(() => {})
+          }
+        }, 700)
+      }
     }
-  }, [ensureSessionRecorder, hasStarted, playAssistantResponse, playWithSpeechSynthesis, pushLog])
+  }, [ensureSessionRecorder, hasStarted, playAssistantResponse, playWithSpeechSynthesis, pushLog, runTurnLoop, sessionId])
 
   const requestFinish = useCallback(async () => {
     if (finishRequestedRef.current) return
@@ -546,6 +675,12 @@ export default function Home() {
     await finalizeNow()
   }, [finalizeNow, pushLog])
 
+  useEffect(() => {
+    if (!sessionId) return
+    if (hasStarted) return
+    startSession().catch(() => {})
+  }, [hasStarted, sessionId, startSession])
+
   const onNext = useCallback(async () => {
     if (disabledNext) return
     if (!hasStarted) {
@@ -557,59 +692,122 @@ export default function Home() {
     }
   }, [disabledNext, hasStarted, runTurnLoop, startSession])
 
+  const visual = STATE_VISUALS[machineState] ?? STATE_VISUALS.idle
+  const isInitialState = !hasStarted && machineState === 'idle'
+  const heroBadge = finishRequested ? 'Finishing' : visual.badge
+  const heroIcon = finishRequested ? '📁' : visual.icon
+  const heroTitle = finishRequested ? 'Wrapping up' : isInitialState ? 'Ready to begin' : visual.title
+  const heroDescription = finishRequested
+    ? 'Hold tight while I save your conversation and prepare your history.'
+    : isInitialState
+      ? 'I’ll start with a welcome and remember every word you share.'
+      : disabledNext && machineState === 'thinking'
+        ? 'Working through what you just said—this only takes a moment.'
+        : disabledNext
+          ? 'I’m listening closely. Take your time and keep talking whenever you’re ready.'
+          : visual.description
+  const heroGradient = finishRequested ? 'from-amber-400/40 via-amber-500/40 to-orange-500/40' : visual.gradient
+  const statusMessage = !hasStarted
+    ? 'Preparing to begin—I’ll speak first.'
+    : finishRequested
+      ? 'Wrapping up your session.'
+      : machineState === 'doneSuccess'
+        ? 'Session saved. Tap Start Again to record another memory.'
+        : disabledNext
+          ? machineState === 'thinking'
+            ? 'Processing your story...'
+            : 'Listening for you now. Take your time.'
+          : 'I’m ready when you are—just start speaking.'
+
   return (
-    <main className="mt-8">
-      <div className="flex flex-col items-center gap-6">
-        <div className="text-sm opacity-80">
-          {!hasStarted
-            ? 'Ready'
-            : finishRequested
-              ? 'Wrapping up the session'
-              : disabledNext
-                ? 'Working...'
-                : 'Tap Next to continue'}
+    <main className="mt-6 flex justify-center px-4 pb-16">
+      <div className="flex w-full max-w-4xl flex-col items-center gap-12">
+        <div className="flex w-full flex-col items-center gap-8">
+          <div className="relative w-full max-w-[min(90vw,460px)]">
+            <div className="relative aspect-square w-full">
+              <div className="absolute inset-0 rounded-full bg-black/20 blur-3xl" aria-hidden="true" />
+              <div
+                className={`absolute inset-[8%] rounded-full bg-gradient-to-br ${heroGradient} animate-soft-pulse shadow-[0_0_80px_rgba(255,255,255,0.18)]`}
+                aria-hidden="true"
+              />
+              <div className="absolute inset-[12%] rounded-full border border-white/15 bg-black/50 backdrop-blur-sm" aria-hidden="true" />
+              <div className="absolute inset-[18%] rounded-full border border-white/10 animate-slow-ripple" aria-hidden="true" />
+              <div
+                className="absolute inset-[18%] rounded-full border border-white/5 animate-slow-ripple"
+                style={{ animationDelay: '1.2s' }}
+                aria-hidden="true"
+              />
+              <div className="absolute inset-[18%] flex flex-col items-center justify-center px-8 text-center">
+                <div className="text-5xl md:text-6xl" aria-hidden="true">
+                  {heroIcon}
+                </div>
+                <div className="mt-4 text-[11px] uppercase tracking-[0.45em] text-white/50">{heroBadge}</div>
+                <div className="mt-3 text-3xl font-semibold md:text-4xl">{heroTitle}</div>
+                <p className="mt-4 text-sm text-white/70 md:text-base">{heroDescription}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center gap-4">
+            <div className="text-sm text-white/70">{statusMessage}</div>
+            {machineState !== 'doneSuccess' ? (
+              <button
+                onClick={onNext}
+                disabled={disabledNext}
+                className="rounded-full bg-white px-10 py-3 text-lg font-semibold text-black shadow-xl transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60 disabled:cursor-not-allowed disabled:bg-white/70 disabled:text-black/60"
+              >
+                Next
+              </button>
+            ) : (
+              <button
+                onClick={() => {
+                  try {
+                    recorderRef.current?.cancel()
+                  } catch {}
+                  recorderRef.current = null
+                  sessionAudioUrlRef.current = null
+                  sessionAudioDurationRef.current = 0
+                  conversationRef.current = []
+                  setHasStarted(false)
+                  setTurn(0)
+                  setFinishRequested(false)
+                  finishRequestedRef.current = false
+                }}
+                className="rounded-full bg-white px-8 py-3 text-lg font-semibold text-black shadow-lg transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+              >
+                Start Again
+              </button>
+            )}
+            {machineState !== 'doneSuccess' && (
+              <button
+                onClick={requestFinish}
+                disabled={!hasStarted || finishRequested}
+                className="text-sm text-white/70 underline-offset-4 transition hover:text-white disabled:cursor-not-allowed disabled:text-white/40"
+              >
+                I’m finished
+              </button>
+            )}
+          </div>
         </div>
 
-        <div className="flex gap-3">
-          {machineState !== 'doneSuccess' ? (
-            <button onClick={onNext} disabled={disabledNext} className="text-sm bg-white/10 px-3 py-1 rounded-2xl disabled:opacity-50">
-              Next
-            </button>
-          ) : (
-            <button
-              onClick={() => {
-                try {
-                  recorderRef.current?.cancel()
-                } catch {}
-                recorderRef.current = null
-                sessionAudioUrlRef.current = null
-                sessionAudioDurationRef.current = 0
-                setHasStarted(false)
-                setTurn(0)
-                setFinishRequested(false)
-                finishRequestedRef.current = false
-              }}
-              className="text-sm bg-white/10 px-3 py-1 rounded-2xl"
-            >
-              Start Again
-            </button>
-          )}
-          {machineState !== 'doneSuccess' && (
-            <button
-              onClick={requestFinish}
-              disabled={!hasStarted || finishRequested}
-              className="text-sm bg-white/10 px-3 py-1 rounded-2xl disabled:opacity-50"
-            >
-              I'm finished
-            </button>
-          )}
-        </div>
-
-        <div className="w-full max-w-xl">
-          <label className="text-xs opacity-70">On-screen Log (copy to share diagnostics):</label>
-          <textarea value={debugLog.join('\n')} readOnly className="w-full h-56 bg-black/30 p-2 rounded" />
-          <div className="mt-2 text-xs opacity-70">
-            Need more? Visit <a className="underline" href="/diagnostics">Diagnostics</a>.
+        <div className="w-full max-w-2xl">
+          <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.4em] text-white/40">
+            <span>Diagnostics log</span>
+            <a className="text-xs font-medium uppercase tracking-[0.2em] text-white/50 underline hover:text-white/80" href="/diagnostics">
+              Open
+            </a>
+          </div>
+          <textarea
+            value={debugLog.join('\n')}
+            readOnly
+            className="mt-2 h-28 w-full resize-none rounded border border-white/10 bg-black/30 p-3 text-[11px] leading-relaxed text-white/70"
+          />
+          <div className="mt-1 text-[11px] text-white/40">
+            Need more detail?{' '}
+            <a className="underline hover:text-white/80" href="/diagnostics">
+              Visit Diagnostics
+            </a>
+            .
           </div>
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -726,13 +726,15 @@ export default function Home() {
       }
 
       const completionIntent = detectCompletionIntent(transcript)
+      const completionDetected = completionIntent.shouldStop && completionIntent.confidence !== 'low'
       if (completionIntent.shouldStop) {
         const match = completionIntent.matchedPhrases.join(', ')
-        pushLog(
-          match.length
-            ? `Completion intent detected (${completionIntent.confidence}): ${match}`
-            : `Completion intent detected (${completionIntent.confidence})`,
-        )
+        const suffix = match.length ? `: ${match}` : ''
+        if (completionDetected) {
+          pushLog(`Completion intent detected (${completionIntent.confidence})${suffix}`)
+        } else {
+          pushLog(`Low-confidence completion intent ignored (${completionIntent.confidence})${suffix}`)
+        }
       }
 
       let assistantPlayback: AssistantPlayback = { base64: null, mime: 'audio/mpeg', durationMs: 0 }
@@ -800,7 +802,7 @@ export default function Home() {
       pushLog('Finished playing → ready')
       const reachedMax = nextTurn >= MAX_TURNS
       const shouldEnd =
-        finishRequestedRef.current || endIntent || reachedMax || completionIntent.shouldStop
+        finishRequestedRef.current || endIntent || reachedMax || completionDetected
       inTurnRef.current = false
 
       if (shouldEnd) {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,19 +3,41 @@ import { useState, useEffect } from 'react'
 
 export default function SettingsPage() {
   const [email, setEmail] = useState('')
+  const [sendEmails, setSendEmails] = useState(true)
   const [saved, setSaved] = useState(false)
 
   useEffect(() => {
     setEmail(localStorage.getItem('defaultEmail') || 'a@sarva.co')
+    const raw = localStorage.getItem('sendSummaryEmails')
+    setSendEmails(raw === null ? true : raw !== 'false')
   }, [])
+
+  useEffect(() => {
+    setSaved(false)
+  }, [email, sendEmails])
 
   return (
     <main>
       <h2 className="text-lg font-semibold mb-4">Settings</h2>
       <label className="block text-sm mb-1">Default notify email</label>
       <input value={email} onChange={e=>setEmail(e.target.value)} className="bg-white/10 rounded p-2 w-full max-w-md" />
+      <label className="flex items-center gap-2 text-sm mt-4">
+        <input
+          type="checkbox"
+          checked={sendEmails}
+          onChange={e => setSendEmails(e.target.checked)}
+        />
+        <span>Send session summaries by email</span>
+      </label>
       <div className="mt-3">
-        <button onClick={()=>{ localStorage.setItem('defaultEmail', email); setSaved(true); }} className="bg-white/10">Save</button>
+        <button
+          onClick={()=>{
+            localStorage.setItem('defaultEmail', email)
+            localStorage.setItem('sendSummaryEmails', sendEmails ? 'true' : 'false')
+            setSaved(true)
+          }}
+          className="bg-white/10 px-4 py-1 rounded"
+        >Save</button>
         {saved && <span className="text-xs ml-3 opacity-70">Saved.</span>}
       </div>
     </main>

--- a/lib/audio-bridge.ts
+++ b/lib/audio-bridge.ts
@@ -6,11 +6,9 @@ export type RecordResult = { blob: Blob; durationMs: number }
 async function getModule(): Promise<any> {
   // Dynamic import so it only loads client-side
   try {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return await import('../src/lib/audio.js')
   } catch {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return await import('../src/lib/audio')
   }

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,7 +1,16 @@
 import { Resend } from 'resend'
 
 export function areSummaryEmailsEnabled() {
-  return process.env.ENABLE_SESSION_EMAILS === 'true'
+  const raw = process.env.ENABLE_SESSION_EMAILS
+  if (raw === undefined) return true
+  const normalized = raw.trim().toLowerCase()
+  if (['false', '0', 'off', 'disable', 'disabled'].includes(normalized)) {
+    return false
+  }
+  if (['true', '1', 'on', 'enable', 'enabled'].includes(normalized)) {
+    return true
+  }
+  return true
 }
 
 export async function sendSummaryEmail(to: string, subject: string, body: string) {
@@ -9,6 +18,11 @@ export async function sendSummaryEmail(to: string, subject: string, body: string
 
   if (!areSummaryEmailsEnabled()) {
     console.info('Session summary email delivery disabled via ENABLE_SESSION_EMAILS flag.')
+    return { skipped: true }
+  }
+
+  if (!to || !/.+@.+/.test(to)) {
+    console.info('Session summary email skipped because no valid recipient was provided.')
     return { skipped: true }
   }
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,7 +1,16 @@
 import { Resend } from 'resend'
 
+export function areSummaryEmailsEnabled() {
+  return process.env.ENABLE_SESSION_EMAILS === 'true'
+}
+
 export async function sendSummaryEmail(to: string, subject: string, body: string) {
   const from = process.env.MAIL_FROM || 'noreply@example.com'
+
+  if (!areSummaryEmailsEnabled()) {
+    console.info('Session summary email delivery disabled via ENABLE_SESSION_EMAILS flag.')
+    return { skipped: true }
+  }
 
   if (process.env.RESEND_API_KEY) {
     try {

--- a/lib/intents.ts
+++ b/lib/intents.ts
@@ -1,0 +1,124 @@
+export type CompletionIntent = {
+  shouldStop: boolean
+  confidence: 'low' | 'medium' | 'high'
+  matchedPhrases: string[]
+}
+
+const NEGATING_PHRASES = [
+  /not\s+done/i,
+  /not\s+finished/i,
+  /not\s+yet/i,
+  /(?:when|once)\s+i\s+(?:am|was|were)?\s*(?:done|finished)/i,
+]
+
+const PATTERN_LIBRARY: { pattern: RegExp; weight: number; phrase: string }[] = [
+  { pattern: /(i['\s]?m|i am)\s+(done|finished|good)\b/, weight: 2.5, phrase: "i'm done" },
+  { pattern: /(we['\s]?re|we are)\s+(done|finished)\b/, weight: 2.3, phrase: "we are done" },
+  { pattern: /(that['\s]?s|that is)\s+(it|all|enough)\b/, weight: 2.1, phrase: "that's it" },
+  { pattern: /(let['\s]?s|lets)\s+(stop|wrap up|call it a day|pause)/, weight: 2.2, phrase: "let's wrap up" },
+  { pattern: /(can|could|may|should)\s+we\s+(stop|wrap up|pause|finish)\b/, weight: 2.2, phrase: 'can we stop' },
+  { pattern: /(stop|end)\s+(the\s+)?(session|conversation|recording|interview)\b/, weight: 2.4, phrase: 'stop the session' },
+  { pattern: /(stop|pause)\s+(here|there|for now)/, weight: 2.1, phrase: 'stop here' },
+  { pattern: /(call)\s+it\s+(a day|there)/, weight: 2.0, phrase: 'call it a day' },
+  { pattern: /(pick|take)\s+(this|it)\s+up\s+(later|another time)/, weight: 1.8, phrase: 'pick this up later' },
+  { pattern: /(talk|speak|chat)\s+(later|another time|next time)/, weight: 1.8, phrase: 'talk later' },
+  { pattern: /(goodbye|bye for now|bye-bye)/, weight: 1.7, phrase: 'goodbye' },
+  { pattern: /(no more|nothing else)\s+(questions|for now|today)/, weight: 2.0, phrase: 'no more questions' },
+  { pattern: /(that will|that'll)\s+be\s+all/, weight: 2.2, phrase: "that will be all" },
+  { pattern: /(thank you|thanks)[,!\s]+(that['\s]?s|that is)\s+(all|it|enough)/, weight: 2.3, phrase: "thanks that's all" },
+  { pattern: /(i|we)\s+(need|have)\s+to\s+(go|run|leave)/, weight: 1.6, phrase: 'i have to go' },
+  { pattern: /(i['\s]?m|i am)\s+(wrapping|signing)\s+off/, weight: 1.9, phrase: "i'm wrapping up" },
+  { pattern: /(enough for|done for|finished for)\s+(now|today|tonight)/, weight: 2.2, phrase: 'enough for now' },
+  { pattern: /(stop|end)\s+(asking|with)\s+(questions|that)/, weight: 1.9, phrase: 'stop with the questions' },
+  { pattern: /(that['\s]?s|that is)\s+probably\s+(enough|good)/, weight: 1.6, phrase: "that's enough" },
+  { pattern: /(wrap|close)\s+(this|things)\s+up/, weight: 2.0, phrase: 'wrap this up' },
+  { pattern: /(i['\s]?ll|i will)\s+(talk|speak|chat)\s+to\s+you\s+(later|soon)/, weight: 1.7, phrase: 'talk to you later' },
+  { pattern: /(we can|let's)\s+(be|call it)\s+(done|good)/, weight: 1.7, phrase: 'call it done' },
+]
+
+const TOKEN_COMBINATIONS: { tokens: string[]; weight: number; phrase: string }[] = [
+  { tokens: ['wrap', 'up'], weight: 1.6, phrase: 'wrap up' },
+  { tokens: ['stop', 'talking'], weight: 1.7, phrase: 'stop talking' },
+  { tokens: ['stop', 'recording'], weight: 1.8, phrase: 'stop recording' },
+  { tokens: ['all', 'done'], weight: 1.6, phrase: 'all done' },
+  { tokens: ['done', 'for', 'now'], weight: 1.9, phrase: 'done for now' },
+  { tokens: ['finished', 'for', 'now'], weight: 1.9, phrase: 'finished for now' },
+  { tokens: ['no', 'more', 'questions'], weight: 2.0, phrase: 'no more questions' },
+  { tokens: ['ready', 'to', 'stop'], weight: 1.6, phrase: 'ready to stop' },
+  { tokens: ['that', 'is', 'it'], weight: 1.6, phrase: 'that is it' },
+]
+
+const STOP_TOKENS = new Set([
+  'done',
+  'finished',
+  'stop',
+  'pause',
+  'wrap',
+  'goodbye',
+  'bye',
+  'later',
+  'enough',
+  'quit',
+  'exit',
+  'over',
+  'complete',
+])
+
+const CONTEXT_TOKENS = new Set(['now', 'today', 'tonight', 'here', 'there', 'anymore', 'for', 'this', 'session', 'conversation'])
+
+export function detectCompletionIntent(input: string | null | undefined): CompletionIntent {
+  const result: CompletionIntent = { shouldStop: false, confidence: 'low', matchedPhrases: [] }
+  if (!input) return result
+
+  const normalized = input.trim().toLowerCase()
+  if (!normalized.length) return result
+
+  for (const neg of NEGATING_PHRASES) {
+    if (neg.test(normalized)) {
+      return result
+    }
+  }
+
+  let score = 0
+  for (const { pattern, weight, phrase } of PATTERN_LIBRARY) {
+    if (pattern.test(normalized)) {
+      score += weight
+      result.matchedPhrases.push(phrase)
+    }
+  }
+
+  const cleanedTokens = normalized.replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(Boolean)
+  const tokenSet = new Set(cleanedTokens)
+
+  for (const { tokens, weight, phrase } of TOKEN_COMBINATIONS) {
+    if (tokens.every((token) => tokenSet.has(token))) {
+      score += weight
+      result.matchedPhrases.push(phrase)
+    }
+  }
+
+  const stopTokenMatches = cleanedTokens.filter((token) => STOP_TOKENS.has(token))
+  const contextMatches = cleanedTokens.filter((token) => CONTEXT_TOKENS.has(token))
+  if (stopTokenMatches.length && contextMatches.length) {
+    score += 1.4
+    result.matchedPhrases.push(`${stopTokenMatches[0]} ${contextMatches[0]}`.trim())
+  }
+
+  if (score >= 3.5) {
+    result.shouldStop = true
+    result.confidence = 'high'
+  } else if (score >= 2.2) {
+    result.shouldStop = true
+    result.confidence = 'medium'
+  } else if (score >= 1.6) {
+    result.shouldStop = true
+    result.confidence = 'low'
+  }
+
+  // Deduplicate matched phrases
+  if (result.matchedPhrases.length) {
+    result.matchedPhrases = Array.from(new Set(result.matchedPhrases))
+  }
+
+  return result
+}

--- a/lib/machine.ts
+++ b/lib/machine.ts
@@ -1,7 +1,15 @@
 'use client'
 import { create } from 'zustand'
 
-type State = 'idle' | 'calibrating' | 'recording' | 'thinking' | 'playing' | 'readyToContinue' | 'doneSuccess'
+type State =
+  | 'idle'
+  | 'calibrating'
+  | 'recording'
+  | 'thinking'
+  | 'speakingPrep'
+  | 'playing'
+  | 'readyToContinue'
+  | 'doneSuccess'
 
 type Store = {
   state: State
@@ -21,6 +29,7 @@ function computeLabel(state: State): string {
     case 'calibrating': return 'Calibrating'
     case 'recording': return 'Done'
     case 'thinking': return 'Cancel'
+    case 'speakingPrep': return 'Continue'
     case 'playing': return 'Continue'
     case 'readyToContinue': return 'Continue'
     case 'doneSuccess': return 'Start Again'
@@ -62,6 +71,11 @@ export const useInterviewMachine = create<Store>((set, get) => ({
     if (state === 'thinking') {
       set({ state: 'readyToContinue', label: computeLabel('readyToContinue'), disabled: false })
       push('Cancelled thinking')
+      return
+    }
+    if (state === 'speakingPrep') {
+      set({ state: 'readyToContinue', label: computeLabel('readyToContinue') })
+      push('Skipped speaking → ready')
       return
     }
     if (state === 'playing') {

--- a/lib/machine.ts
+++ b/lib/machine.ts
@@ -1,7 +1,7 @@
 'use client'
 import { create } from 'zustand'
 
-type State = 'idle' | 'recording' | 'thinking' | 'playing' | 'readyToContinue' | 'doneSuccess'
+type State = 'idle' | 'calibrating' | 'recording' | 'thinking' | 'playing' | 'readyToContinue' | 'doneSuccess'
 
 type Store = {
   state: State
@@ -18,6 +18,7 @@ type Store = {
 function computeLabel(state: State): string {
   switch(state){
     case 'idle': return 'Start'
+    case 'calibrating': return 'Calibrating'
     case 'recording': return 'Done'
     case 'thinking': return 'Cancel'
     case 'playing': return 'Continue'
@@ -42,6 +43,11 @@ export const useInterviewMachine = create<Store>((set, get) => ({
     if (state === 'idle') {
       set({ state: 'recording', label: computeLabel('recording') })
       push('Recording started')
+      return
+    }
+    if (state === 'calibrating') {
+      push('Skipping calibration → recording')
+      set({ state: 'recording', label: computeLabel('recording') })
       return
     }
     if (state === 'recording') {

--- a/lib/question-memory.ts
+++ b/lib/question-memory.ts
@@ -1,0 +1,89 @@
+import type { SessionMemorySnapshot } from './data'
+
+const FALLBACK_QUESTION_POOL = [
+  'What tiny detail from that moment still feels sharp to you?',
+  'Who else was nearby, and what do you remember about them?',
+  'What sounds or scents come back when you picture it?',
+  'What happened just before that scene unfolded?',
+  'How did you feel right after it happened?',
+  'Is there an object or keepsake that still reminds you of it?',
+  'What was the weather or light like around you?',
+  'What music or voices were in the background?',
+  'What did you eat or drink around that time?',
+  'What colors or textures stand out when you think about it?',
+]
+
+export function normalizeQuestion(question: string): string {
+  return question
+    .toLowerCase()
+    .replace(/[^a-z0-9?\s]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function extractAskedQuestions(text: string): string[] {
+  if (!text || !text.length) return []
+  const matches = text.match(/[^?]*\?/g)
+  if (!matches) return []
+  return matches.map((question) => question.trim()).filter(Boolean)
+}
+
+export function collectAskedQuestions(sessions: SessionMemorySnapshot[]): string[] {
+  const questions: string[] = []
+  for (const session of sessions) {
+    for (const turn of session.turns) {
+      if (turn.role !== 'assistant' || !turn.text) continue
+      questions.push(...extractAskedQuestions(turn.text))
+    }
+  }
+  return questions
+}
+
+export function findLatestUserDetails(
+  sessions: SessionMemorySnapshot[],
+  options: { excludeSessionId?: string; limit?: number } = {},
+): string[] {
+  const details: string[] = []
+  const { excludeSessionId, limit = 2 } = options
+  for (const session of sessions) {
+    if (excludeSessionId && session.id === excludeSessionId) continue
+    for (let index = session.turns.length - 1; index >= 0; index -= 1) {
+      const turn = session.turns[index]
+      if (turn.role === 'user' && turn.text && turn.text.trim().length) {
+        details.push(turn.text.trim())
+        break
+      }
+    }
+    if (details.length >= limit) break
+  }
+  return details.slice(0, limit)
+}
+
+function compressDetail(detail: string): string {
+  const words = detail.split(/\s+/).filter(Boolean)
+  if (words.length <= 14) return detail
+  return words.slice(0, 14).join(' ') + '...'
+}
+
+export function pickFallbackQuestion(asked: Iterable<string>, detail?: string): string {
+  const normalized = new Set<string>()
+  for (const question of asked) {
+    if (!question) continue
+    normalized.add(normalizeQuestion(question))
+  }
+
+  if (detail) {
+    const detailQuestion = `When you think about ${compressDetail(detail)}, what else stands out now?`
+    if (!normalized.has(normalizeQuestion(detailQuestion))) {
+      return detailQuestion
+    }
+  }
+
+  for (const candidate of FALLBACK_QUESTION_POOL) {
+    if (!normalized.has(normalizeQuestion(candidate))) {
+      return candidate
+    }
+  }
+
+  return 'Tell me one detail you have not shared with me yet.'
+}

--- a/lib/session-title.ts
+++ b/lib/session-title.ts
@@ -1,0 +1,86 @@
+export type SummarizableTurn = {
+  role: 'user' | 'assistant'
+  text?: string | null
+}
+
+function splitIntoSentences(text: string): string[] {
+  const cleaned = text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()
+  if (!cleaned) return []
+  const sentences = cleaned
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.replace(/^['"“”]+|['"“”]+$/g, '').trim())
+    .filter(Boolean)
+  if (sentences.length) return sentences
+  return [cleaned]
+}
+
+function scoreSentence(sentence: string, role: SummarizableTurn['role']): number {
+  let score = 0
+  const length = sentence.length
+  if (length >= 12) score += Math.min(1.5, length / 80)
+  if (/[,:;]/.test(sentence)) score += 0.2
+  if (/(because|when|after|before|while|remember|recall|story|moment|detail)/i.test(sentence)) score += 0.6
+  if (/\b(I|We|My|Our|He|She|They)\b/.test(sentence)) score += 0.4
+  if (role === 'user') score += 1.1
+  else score += 0.4
+  return score
+}
+
+function finalizeSentence(sentence: string): string {
+  let result = sentence.replace(/\s+/g, ' ').trim()
+  if (!result) return ''
+  result = result.charAt(0).toUpperCase() + result.slice(1)
+  const limit = 120
+  if (result.length > limit) {
+    const truncated = result.slice(0, limit - 1)
+    const lastSpace = truncated.lastIndexOf(' ')
+    if (lastSpace > 40) {
+      result = truncated.slice(0, lastSpace) + '…'
+    } else {
+      result = truncated + '…'
+    }
+    return result
+  }
+  if (!/[.!?…]$/.test(result)) {
+    result += '.'
+  }
+  return result
+}
+
+export function generateSessionTitle(
+  turns: SummarizableTurn[] | undefined | null,
+  options: { fallback?: string } = {},
+): string | undefined {
+  const fallback = options.fallback
+  if (!turns || !turns.length) {
+    return fallback
+  }
+
+  const candidates: { sentence: string; score: number; role: SummarizableTurn['role'] }[] = []
+
+  for (const turn of turns) {
+    if (!turn || typeof turn.text !== 'string') continue
+    const trimmed = turn.text.replace(/\s+/g, ' ').trim()
+    if (!trimmed) continue
+    const sentences = splitIntoSentences(trimmed)
+    for (const sentence of sentences) {
+      const scored = scoreSentence(sentence, turn.role)
+      if (scored <= 0) continue
+      candidates.push({ sentence, score: scored, role: turn.role })
+    }
+  }
+
+  if (!candidates.length) {
+    return fallback
+  }
+
+  candidates.sort((a, b) => b.score - a.score)
+
+  const preferred = candidates.find((entry) => entry.role === 'user' && entry.sentence.split(' ').length >= 3)
+  const chosen = preferred || candidates[0]
+  const finalized = finalizeSentence(chosen.sentence)
+  if (finalized) {
+    return finalized
+  }
+  return fallback
+}

--- a/src/lib/audio.js
+++ b/src/lib/audio.js
@@ -1,41 +1,136 @@
-function createBandpass(ctx){ const hp=ctx.createBiquadFilter(); hp.type='highpass'; hp.frequency.value=250; const lp=ctx.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=3600; hp.connect(lp); return {input:hp, output:lp} }
-function rms(buf){ let s=0; for(let i=0;i<buf.length;i++) s+=buf[i]*buf[i]; return Math.sqrt(s/buf.length) }
-
-export async function calibrateRMS(seconds=2.0){
-  const stream = await navigator.mediaDevices.getUserMedia({audio:true})
-  const ctx = new AudioContext(); const src = ctx.createMediaStreamSource(stream); const {input,output}=createBandpass(ctx); src.connect(input)
-  const an = ctx.createAnalyser(); an.fftSize=2048; output.connect(an)
-  const data = new Float32Array(an.fftSize); const vals=[]; const end=performance.now()+seconds*1000
-  while(performance.now()<end){ an.getFloatTimeDomainData(data); vals.push(rms(data)); await new Promise(r=>setTimeout(r,50)) }
-  vals.sort((a,b)=>a-b); const med = vals[Math.floor(vals.length/2)]||0.01
-  stream.getTracks().forEach(t=>t.stop()); await ctx.close(); return med
+function createBandpass(ctx) {
+  const hp = ctx.createBiquadFilter()
+  hp.type = 'highpass'
+  hp.frequency.value = 250
+  const lp = ctx.createBiquadFilter()
+  lp.type = 'lowpass'
+  lp.frequency.value = 3600
+  hp.connect(lp)
+  return { input: hp, output: lp }
 }
 
-export async function recordUntilSilence({baseline, minDurationMs=1200, maxDurationMs=180000, silenceMs=1600, graceMs=600, shouldForceStop=()=>false}){
-  const stream = await navigator.mediaDevices.getUserMedia({audio:true})
-  const ctx = new AudioContext(); const src = ctx.createMediaStreamSource(stream); const {input,output}=createBandpass(ctx); src.connect(input)
-  const an = ctx.createAnalyser(); an.fftSize=2048; output.connect(an)
-  const proc = ctx.createScriptProcessor(2048,1,1); output.connect(proc); proc.connect(ctx.destination)
-  const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')?'audio/webm;codecs=opus':'audio/webm'
-  const rec = new MediaRecorder(stream,{mimeType:mime}); const chunks=[]; rec.ondataavailable=e=>{if(e.data&&e.data.size)chunks.push(e.data)}
-  let started=false, startedAt=0, lastLoud=performance.now(), quietStreak=0, loudStreak=0
+function rms(buf) {
+  let sum = 0
+  for (let i = 0; i < buf.length; i++) sum += buf[i] * buf[i]
+  return Math.sqrt(sum / buf.length)
+}
+
+export async function calibrateRMS(seconds = 2.0) {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+  const ctx = new AudioContext()
+  const src = ctx.createMediaStreamSource(stream)
+  const { input, output } = createBandpass(ctx)
+  src.connect(input)
+  const an = ctx.createAnalyser()
+  an.fftSize = 2048
+  output.connect(an)
   const data = new Float32Array(an.fftSize)
-  return await new Promise((resolve)=>{
-    rec.onstop=()=>{ const blob=new Blob(chunks,{type:mime}); const durationMs=Math.max(0,performance.now()-startedAt); cleanup(); resolve({blob,durationMs}) }
-    proc.onaudioprocess=()=>{
-      an.getFloatTimeDomainData(data); const level = baseline>0 ? rms(data)/baseline : 0; const now = performance.now()
-      if(!started){ if(level>=3.0){ if(++loudStreak>=3){ started=true; startedAt=now; rec.start() } } else loudStreak=0 }
-      else{ if(level<2.0) quietStreak++; else { quietStreak=0; lastLoud=now }
-        const elapsed=now-startedAt, silenceElapsed=now-lastLoud
-        if(elapsed>=maxDurationMs) rec.stop()
-        else if(shouldForceStop() && elapsed>=minDurationMs) rec.stop()
-        else if(elapsed>=minDurationMs && quietStreak>=8 && silenceElapsed>=(silenceMs+graceMs)) rec.stop()
+  const vals = []
+  const end = performance.now() + seconds * 1000
+  while (performance.now() < end) {
+    an.getFloatTimeDomainData(data)
+    vals.push(rms(data))
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  vals.sort((a, b) => a - b)
+  const med = vals[Math.floor(vals.length / 2)] || 0.01
+  stream.getTracks().forEach((t) => t.stop())
+  await ctx.close()
+  return med
+}
+
+export async function recordUntilSilence(options) {
+  const {
+    baseline,
+    minDurationMs = 1200,
+    maxDurationMs = 180000,
+    silenceMs = 1600,
+    graceMs = 600,
+    shouldForceStop = () => false,
+    startRatio = 3.0,
+    stopRatio = 2.0,
+  } = options
+
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+  const ctx = new AudioContext()
+  const src = ctx.createMediaStreamSource(stream)
+  const { input, output } = createBandpass(ctx)
+  src.connect(input)
+  const an = ctx.createAnalyser()
+  an.fftSize = 2048
+  output.connect(an)
+  const proc = ctx.createScriptProcessor(2048, 1, 1)
+  output.connect(proc)
+  proc.connect(ctx.destination)
+  const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+    ? 'audio/webm;codecs=opus'
+    : 'audio/webm'
+  const rec = new MediaRecorder(stream, { mimeType: mime })
+  const chunks = []
+  rec.ondataavailable = (e) => {
+    if (e.data && e.data.size) chunks.push(e.data)
+  }
+  let started = false
+  let startedAt = 0
+  let lastLoud = performance.now()
+  let quietStreak = 0
+  let loudStreak = 0
+  const data = new Float32Array(an.fftSize)
+
+  return await new Promise((resolve) => {
+    rec.onstop = () => {
+      const blob = new Blob(chunks, { type: mime })
+      const durationMs = Math.max(0, performance.now() - startedAt)
+      cleanup()
+      resolve({ blob, durationMs })
+    }
+    proc.onaudioprocess = () => {
+      an.getFloatTimeDomainData(data)
+      const safeBaseline = baseline > 0.0001 ? baseline : 0.0001
+      const level = rms(data) / safeBaseline
+      const now = performance.now()
+      if (!started) {
+        if (level >= startRatio) {
+          if (++loudStreak >= 3) {
+            started = true
+            startedAt = now
+            rec.start()
+          }
+        } else {
+          loudStreak = 0
+        }
+      } else {
+        if (level < stopRatio) quietStreak++
+        else {
+          quietStreak = 0
+          lastLoud = now
+        }
+        const elapsed = now - startedAt
+        const silenceElapsed = now - lastLoud
+        if (elapsed >= maxDurationMs) rec.stop()
+        else if (shouldForceStop() && elapsed >= minDurationMs) rec.stop()
+        else if (elapsed >= minDurationMs && quietStreak >= 8 && silenceElapsed >= silenceMs + graceMs) rec.stop()
       }
     }
-    function cleanup(){ try{proc.disconnect(); output.disconnect()}catch{} try{stream.getTracks().forEach(t=>t.stop())}catch{} try{ctx.close()}catch{} }
+    function cleanup() {
+      try {
+        proc.disconnect()
+        output.disconnect()
+      } catch {}
+      try {
+        stream.getTracks().forEach((t) => t.stop())
+      } catch {}
+      try {
+        ctx.close()
+      } catch {}
+    }
   })
 }
 
-export async function blobToBase64(blob){
-  return new Promise(res=>{ const r=new FileReader(); r.onload=()=>res(String(r.result).split(',')[1]); r.readAsDataURL(blob) })
+export async function blobToBase64(blob) {
+  return new Promise((res) => {
+    const reader = new FileReader()
+    reader.onload = () => res(String(reader.result).split(',')[1])
+    reader.readAsDataURL(blob)
+  })
 }

--- a/tests/blob.test.ts
+++ b/tests/blob.test.ts
@@ -17,6 +17,7 @@ describe('putBlobFromBuffer', () => {
     vi.doMock('@vercel/blob', () => ({
       put: putSpy,
       list: vi.fn(),
+      del: vi.fn(),
     }))
     const { putBlobFromBuffer } = await import('../lib/blob')
     const result = await putBlobFromBuffer('path/file.txt', Buffer.from('hello'), 'text/plain')
@@ -36,6 +37,7 @@ describe('putBlobFromBuffer', () => {
     vi.doMock('@vercel/blob', () => ({
       put: vi.fn(),
       list: vi.fn(),
+      del: vi.fn(),
     }))
     const { putBlobFromBuffer } = await import('../lib/blob')
     const result = await putBlobFromBuffer('path/file.txt', Buffer.from('hi'), 'text/plain')
@@ -50,6 +52,7 @@ describe('listBlobs', () => {
     vi.doMock('@vercel/blob', () => ({
       put: vi.fn(),
       list: vi.fn(),
+      del: vi.fn(),
     }))
     const { putBlobFromBuffer, listBlobs, clearFallbackBlobs } = await import('../lib/blob')
     clearFallbackBlobs()

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -34,8 +34,11 @@ describe('finalizeSession', () => {
 
     expect(result.emailed).toBe(true)
     expect(result.emailStatus).toEqual({ ok: true, provider: 'resend' })
+    expect(result.session.title && result.session.title.length).toBeTruthy()
+    expect(result.session.title?.toLowerCase()).not.toContain('untitled')
     const stored = await data.getSession(session.id)
     expect(stored?.status).toBe('emailed')
+    expect(stored?.title && stored.title.length).toBeTruthy()
   })
 
   it('handles skipped email when no provider configured', async () => {
@@ -53,6 +56,7 @@ describe('finalizeSession', () => {
     expect(result.emailStatus).toEqual({ skipped: true })
     const stored = await data.getSession(session.id)
     expect(stored?.status).toBe('completed')
+    expect(stored?.title && stored.title.length).toBeTruthy()
   })
 
   it('flags failures from the email provider', async () => {
@@ -70,6 +74,7 @@ describe('finalizeSession', () => {
     expect(result.emailStatus).toEqual({ ok: false, provider: 'resend', error: 'bad' })
     const stored = await data.getSession(session.id)
     expect(stored?.status).toBe('error')
+    expect(stored?.title && stored.title.length).toBeTruthy()
     const foxes = listFoxes()
     expect(foxes.some((fox) => fox.id === 'theory-4-email-status-error')).toBe(true)
   })

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -79,6 +79,22 @@ describe('finalizeSession', () => {
     expect(foxes.some((fox) => fox.id === 'theory-4-email-status-error')).toBe(true)
   })
 
+  it('skips summary email when the session has no recipient', async () => {
+    const data = await import('../lib/data')
+    const session = await data.createSession({ email_to: '' })
+    await data.appendTurn(session.id, { role: 'assistant', text: 'hello there' })
+
+    const result = await data.finalizeSession(session.id, { clientDurationMs: 10 })
+    if (!('session' in result)) {
+      throw new Error('Expected session result')
+    }
+
+    expect(sendEmailMock).not.toHaveBeenCalled()
+    expect(result.emailed).toBe(false)
+    expect(result.emailStatus).toEqual({ skipped: true })
+    expect(result.session.status).toBe('completed')
+  })
+
   it('persists session audio artifacts when provided', async () => {
     const data = await import('../lib/data')
     sendEmailMock.mockResolvedValue({ skipped: true })

--- a/tests/intents.test.ts
+++ b/tests/intents.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { detectCompletionIntent } from '../lib/intents'
+
+describe('detectCompletionIntent', () => {
+  const positives = [
+    "I'm done for now",
+    'That will be all, thank you.',
+    "Let's wrap this up",
+    'Can we stop the conversation here?',
+    'Thanks, that is enough for today.',
+    "I'll talk to you later",
+    'We are finished. Goodbye.',
+    'No more questions for now.',
+    'Please stop recording the session.',
+  ]
+
+  for (const phrase of positives) {
+    it(`detects completion intent for "${phrase}"`, () => {
+      const intent = detectCompletionIntent(phrase)
+      expect(intent.shouldStop).toBe(true)
+    })
+  }
+
+  const negatives = [
+    "I'm not done yet",
+    'When I am done with school I felt relieved.',
+    'We should stop by the store before dinner.',
+    'Later on, I finished the painting.',
+    'That is itched into my memory.',
+  ]
+
+  for (const phrase of negatives) {
+    it(`does not flag unrelated phrase "${phrase}"`, () => {
+      const intent = detectCompletionIntent(phrase)
+      expect(intent.shouldStop).toBe(false)
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- auto-start the home session with a dynamic greeting and automatically resume recording so the voice flow begins without tapping Next
- add a memory-aware intro endpoint plus shared question-memory utilities so greetings and follow-up prompts reference prior transcripts and avoid repeats
- feed session history into the ask-audio endpoint to keep subsequent questions fresh even when falling back to canned prompts

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce184d8114832ab48e8e343add959b