### PR TITLE
Ignore provider end intent without user signal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -727,6 +727,7 @@ export default function Home() {
 
       const completionIntent = detectCompletionIntent(transcript)
       const completionDetected = completionIntent.shouldStop && completionIntent.confidence !== 'low'
+      const providerSuggestedStop = endIntent === true
       if (completionIntent.shouldStop) {
         const match = completionIntent.matchedPhrases.join(', ')
         const suffix = match.length ? `: ${match}` : ''
@@ -801,8 +802,12 @@ export default function Home() {
 
       pushLog('Finished playing → ready')
       const reachedMax = nextTurn >= MAX_TURNS
+      if (providerSuggestedStop && !completionDetected && !finishRequestedRef.current) {
+        pushLog('Provider end intent ignored—no user stop detected')
+      }
+
       const shouldEnd =
-        finishRequestedRef.current || endIntent || reachedMax || completionDetected
+        finishRequestedRef.current || reachedMax || completionDetected
       inTurnRef.current = false
 
       if (shouldEnd) {


### PR DESCRIPTION
## Summary
- ignore the model-provided `end_intent` flag unless we also detect the user explicitly asking to stop
- log when the provider suggests ending but no user stop intent is heard so we can debug future cases

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfad9f7550832aa5779a5b10394f32