### PR TITLE
Support user-scoped routes and preferences

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,15 +1,40 @@
-'use client'
+"use client"
 import { useState, useEffect } from 'react'
+import {
+  ACTIVE_USER_HANDLE_STORAGE_KEY,
+  DEFAULT_NOTIFY_EMAIL,
+  EMAIL_ENABLED_STORAGE_BASE_KEY,
+  EMAIL_STORAGE_BASE_KEY,
+  normalizeHandle,
+  scopedStorageKey,
+} from '@/lib/user-scope'
 
 export default function SettingsPage() {
   const [email, setEmail] = useState('')
   const [sendEmails, setSendEmails] = useState(true)
   const [saved, setSaved] = useState(false)
+  const [activeHandle, setActiveHandle] = useState<string | undefined>(undefined)
 
   useEffect(() => {
-    setEmail(localStorage.getItem('defaultEmail') || 'a@sarva.co')
-    const raw = localStorage.getItem('sendSummaryEmails')
-    setSendEmails(raw === null ? true : raw !== 'false')
+    if (typeof window === 'undefined') {
+      setEmail(DEFAULT_NOTIFY_EMAIL)
+      setSendEmails(true)
+      setActiveHandle(undefined)
+      return
+    }
+    try {
+      const storedHandle = normalizeHandle(window.localStorage.getItem(ACTIVE_USER_HANDLE_STORAGE_KEY))
+      setActiveHandle(storedHandle)
+      const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, storedHandle)
+      setEmail(window.localStorage.getItem(emailKey) || DEFAULT_NOTIFY_EMAIL)
+      const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, storedHandle)
+      const raw = window.localStorage.getItem(enabledKey)
+      setSendEmails(raw === null ? true : raw !== 'false')
+    } catch {
+      setEmail(DEFAULT_NOTIFY_EMAIL)
+      setSendEmails(true)
+      setActiveHandle(undefined)
+    }
   }, [])
 
   useEffect(() => {
@@ -19,6 +44,9 @@ export default function SettingsPage() {
   return (
     <main>
       <h2 className="text-lg font-semibold mb-4">Settings</h2>
+      {activeHandle && (
+        <p className="-mt-2 mb-4 text-xs text-white/60">Active account: <span className="font-semibold text-white">@{activeHandle}</span></p>
+      )}
       <label className="block text-sm mb-1">Default notify email</label>
       <input value={email} onChange={e=>setEmail(e.target.value)} className="bg-white/10 rounded p-2 w-full max-w-md" />
       <label className="flex items-center gap-2 text-sm mt-4">
@@ -32,8 +60,10 @@ export default function SettingsPage() {
       <div className="mt-3">
         <button
           onClick={()=>{
-            localStorage.setItem('defaultEmail', email)
-            localStorage.setItem('sendSummaryEmails', sendEmails ? 'true' : 'false')
+            const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, activeHandle)
+            const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, activeHandle)
+            localStorage.setItem(emailKey, email)
+            localStorage.setItem(enabledKey, sendEmails ? 'true' : 'false')
             setSaved(true)
           }}
           className="bg-white/10 px-4 py-1 rounded"

--- a/app/u/[handle]/page.tsx
+++ b/app/u/[handle]/page.tsx
@@ -1,0 +1,6 @@
+import { Home } from '@/app/page'
+
+export default function UserHomePage({ params }: { params: { handle: string } }) {
+  const handle = params.handle || ''
+  return <Home key={`user:${handle.toLowerCase()}`} userHandle={handle} />
+}

--- a/lib/user-scope.ts
+++ b/lib/user-scope.ts
@@ -1,0 +1,25 @@
+export const SESSION_STORAGE_BASE_KEY = 'sessionId'
+export const EMAIL_STORAGE_BASE_KEY = 'defaultEmail'
+export const EMAIL_ENABLED_STORAGE_BASE_KEY = 'sendSummaryEmails'
+export const DEMO_HISTORY_BASE_KEY = 'demoHistory'
+export const ACTIVE_USER_HANDLE_STORAGE_KEY = 'activeUserHandle'
+export const DEFAULT_NOTIFY_EMAIL = 'a@sarva.co'
+
+const DEFAULT_SCOPE_KEY = '__default__'
+
+export function normalizeHandle(handle?: string | null): string | undefined {
+  if (!handle) return undefined
+  if (typeof handle !== 'string') return undefined
+  const trimmed = handle.trim()
+  if (!trimmed.length) return undefined
+  return trimmed.toLowerCase()
+}
+
+export function deriveUserScopeKey(handle?: string | null): string {
+  return normalizeHandle(handle) ?? DEFAULT_SCOPE_KEY
+}
+
+export function scopedStorageKey(base: string, handle?: string | null): string {
+  const normalized = normalizeHandle(handle)
+  return normalized ? `${base}:${normalized}` : base
+}


### PR DESCRIPTION
## Summary
- add user scope helpers and update the home experience to resolve sessions, storage keys, and logs per user handle while surfacing the active account in the UI
- update the history and settings pages to read and write demo artifacts and email preferences for the active handle and show which account is in view
- add a /u/[handle] route that mounts the home experience for a specific user handle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfad9f7550832aa5779a5b10394f32