### PR TITLE
Scope history by user handle and refresh interviewer prompts

### DIFF
--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -8,16 +8,17 @@ import {
 } from '@/lib/question-memory'
 import { detectCompletionIntent } from '@/lib/intents'
 
-const SYSTEM_PROMPT = `You are a warm, curious biographer inspired by the professor and book the family mentioned, but you are not following a rigid script.
+const SYSTEM_PROMPT = `You are a warm, curious biographer inspired by the book “The Essential Questions”, but you are not following a rigid script.
 You remember every conversation provided in the memory section below.
 Principles:
 - Follow the user's lead and respond directly to any instruction, question, or aside before you consider another prompt.
 - Be open to any topic the user brings up, gently weaving the discussion back toward the life-story themes when it feels natural.
 - Never repeat or paraphrase the user's own words, and do not repeat questions listed in the memory section.
+- Quickly summarize what you hear in each response before speaking further.
 - If a reply is brief or uncertain, adapt by changing angles or suggesting a different avenue instead of insisting on the same question.
-- Ask at most one short, specific, sensory-rich question (<= 20 words) only when the user seems ready to keep going.
+- Ask at most one short, specific, open-ended question (<= 20 words) only when the user seems ready to keep going.
 - Keep silence handling patient; do not rush to speak if the user pauses briefly.
-- If the user signals they are finished for now, set end_intent to true and close warmly without pushing another question.
+- If the user signals they are finished for now, set end_intent to true and close warmly without pushing another question. Say you are happy to talk more later.
 Return a JSON object: {"reply":"...", "transcript":"...", "end_intent":true|false}.`
 
 function safeJsonParse(input: string | null | undefined) {

--- a/app/api/session/start/route.ts
+++ b/app/api/session/start/route.ts
@@ -18,10 +18,17 @@ export async function POST(req: NextRequest) {
   const emailsEnabled = payload?.emailsEnabled !== false
   const defaultEmail = process.env.DEFAULT_NOTIFY_EMAIL || 'a@sarva.co'
   const targetEmail = emailsEnabled ? rawEmail || defaultEmail : ''
+  const userHandle =
+    typeof payload?.userHandle === 'string'
+      ? payload.userHandle
+      : typeof payload?.user_handle === 'string'
+      ? payload.user_handle
+      : null
 
   try {
     const session = await createSession({
       email_to: targetEmail,
+      user_handle: userHandle,
     })
     return NextResponse.json({ id: session.id, email: session.email_to, emailsEnabled: emailsEnabled })
   } catch (error: any) {

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,5 +1,11 @@
 "use client"
 import { useCallback, useEffect, useState } from 'react'
+import {
+  ACTIVE_USER_HANDLE_STORAGE_KEY,
+  DEMO_HISTORY_BASE_KEY,
+  normalizeHandle,
+  scopedStorageKey,
+} from '@/lib/user-scope'
 
 type Row = {
   id: string
@@ -24,14 +30,29 @@ export default function HistoryPage() {
   const [rows, setRows] = useState<Row[]>([])
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [clearingAll, setClearingAll] = useState(false)
+  const [activeHandle, setActiveHandle] = useState<string | undefined>(undefined)
+
+  const getActiveHandle = useCallback(() => {
+    if (typeof window === 'undefined') return undefined
+    try {
+      const stored = window.localStorage.getItem(ACTIVE_USER_HANDLE_STORAGE_KEY)
+      return normalizeHandle(stored)
+    } catch {
+      return undefined
+    }
+  }, [])
 
   const loadHistory = useCallback(async () => {
     try {
-      const api = await (await fetch('/api/history')).json()
+      const handle = getActiveHandle()
+      setActiveHandle(handle)
+      const query = handle ? `?handle=${encodeURIComponent(handle)}` : ''
+      const api = await (await fetch(`/api/history${query}`)).json()
       const serverRows: Row[] = api?.items || []
       let demoRows: Row[] = []
       try {
-        const raw = localStorage.getItem('demoHistory')
+        const key = scopedStorageKey(DEMO_HISTORY_BASE_KEY, handle)
+        const raw = localStorage.getItem(key)
         if (raw) {
           const list = JSON.parse(raw) as { id: string; created_at: string; title?: string | null }[]
           demoRows = list.map((d) => ({
@@ -57,7 +78,7 @@ export default function HistoryPage() {
     } catch {
       setRows([])
     }
-  }, [])
+  }, [getActiveHandle])
 
   useEffect(() => {
     loadHistory()
@@ -65,17 +86,19 @@ export default function HistoryPage() {
 
   const removeDemoEntry = useCallback((id: string) => {
     try {
-      const raw = localStorage.getItem('demoHistory')
+      const handle = getActiveHandle()
+      const key = scopedStorageKey(DEMO_HISTORY_BASE_KEY, handle)
+      const raw = localStorage.getItem(key)
       if (!raw) return
       const list = JSON.parse(raw) as { id: string }[]
       const filtered = list.filter((entry) => entry.id !== id)
       if (filtered.length) {
-        localStorage.setItem('demoHistory', JSON.stringify(filtered))
+        localStorage.setItem(key, JSON.stringify(filtered))
       } else {
-        localStorage.removeItem('demoHistory')
+        localStorage.removeItem(key)
       }
     } catch {}
-  }, [])
+  }, [getActiveHandle])
 
   const handleDelete = useCallback(
     async (id: string) => {
@@ -96,19 +119,29 @@ export default function HistoryPage() {
   const handleClearAll = useCallback(async () => {
     setClearingAll(true)
     try {
-      const resp = await fetch('/api/history', { method: 'DELETE' })
+      const handle = getActiveHandle()
+      const query = handle ? `?handle=${encodeURIComponent(handle)}` : ''
+      const resp = await fetch(`/api/history${query}`, { method: 'DELETE' })
       if (resp.ok) {
-        localStorage.removeItem('demoHistory')
+        if (typeof window !== 'undefined') {
+          const scopedKey = scopedStorageKey(DEMO_HISTORY_BASE_KEY, handle)
+          localStorage.removeItem(scopedKey)
+        }
         setRows([])
       }
     } finally {
       setClearingAll(false)
     }
-  }, [])
+  }, [getActiveHandle])
 
   return (
     <main>
       <h2 className="text-lg font-semibold mb-4">Sessions</h2>
+      {activeHandle && (
+        <p className="-mt-2 mb-4 text-xs text-white/60">
+          Showing sessions saved for <span className="font-semibold text-white">@{activeHandle}</span>
+        </p>
+      )}
       {rows.length === 0 ? (
         <div className="rounded border border-dashed border-white/10 bg-white/5 p-4 text-sm text-white/70">
           <p className="font-medium text-white">No interviews yet.</p>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,15 +1,40 @@
-'use client'
+"use client"
 import { useState, useEffect } from 'react'
+import {
+  ACTIVE_USER_HANDLE_STORAGE_KEY,
+  DEFAULT_NOTIFY_EMAIL,
+  EMAIL_ENABLED_STORAGE_BASE_KEY,
+  EMAIL_STORAGE_BASE_KEY,
+  normalizeHandle,
+  scopedStorageKey,
+} from '@/lib/user-scope'
 
 export default function SettingsPage() {
   const [email, setEmail] = useState('')
   const [sendEmails, setSendEmails] = useState(true)
   const [saved, setSaved] = useState(false)
+  const [activeHandle, setActiveHandle] = useState<string | undefined>(undefined)
 
   useEffect(() => {
-    setEmail(localStorage.getItem('defaultEmail') || 'a@sarva.co')
-    const raw = localStorage.getItem('sendSummaryEmails')
-    setSendEmails(raw === null ? true : raw !== 'false')
+    if (typeof window === 'undefined') {
+      setEmail(DEFAULT_NOTIFY_EMAIL)
+      setSendEmails(true)
+      setActiveHandle(undefined)
+      return
+    }
+    try {
+      const storedHandle = normalizeHandle(window.localStorage.getItem(ACTIVE_USER_HANDLE_STORAGE_KEY))
+      setActiveHandle(storedHandle)
+      const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, storedHandle)
+      setEmail(window.localStorage.getItem(emailKey) || DEFAULT_NOTIFY_EMAIL)
+      const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, storedHandle)
+      const raw = window.localStorage.getItem(enabledKey)
+      setSendEmails(raw === null ? true : raw !== 'false')
+    } catch {
+      setEmail(DEFAULT_NOTIFY_EMAIL)
+      setSendEmails(true)
+      setActiveHandle(undefined)
+    }
   }, [])
 
   useEffect(() => {
@@ -19,6 +44,9 @@ export default function SettingsPage() {
   return (
     <main>
       <h2 className="text-lg font-semibold mb-4">Settings</h2>
+      {activeHandle && (
+        <p className="-mt-2 mb-4 text-xs text-white/60">Active account: <span className="font-semibold text-white">@{activeHandle}</span></p>
+      )}
       <label className="block text-sm mb-1">Default notify email</label>
       <input value={email} onChange={e=>setEmail(e.target.value)} className="bg-white/10 rounded p-2 w-full max-w-md" />
       <label className="flex items-center gap-2 text-sm mt-4">
@@ -32,8 +60,10 @@ export default function SettingsPage() {
       <div className="mt-3">
         <button
           onClick={()=>{
-            localStorage.setItem('defaultEmail', email)
-            localStorage.setItem('sendSummaryEmails', sendEmails ? 'true' : 'false')
+            const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, activeHandle)
+            const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, activeHandle)
+            localStorage.setItem(emailKey, email)
+            localStorage.setItem(enabledKey, sendEmails ? 'true' : 'false')
             setSaved(true)
           }}
           className="bg-white/10 px-4 py-1 rounded"

--- a/app/u/[handle]/page.tsx
+++ b/app/u/[handle]/page.tsx
@@ -1,0 +1,6 @@
+import { Home } from '../../page'
+
+export default function UserHomePage({ params }: { params: { handle: string } }) {
+  const handle = params.handle || ''
+  return <Home key={`user:${handle.toLowerCase()}`} userHandle={handle} />
+}

--- a/lib/user-scope.ts
+++ b/lib/user-scope.ts
@@ -1,0 +1,25 @@
+export const SESSION_STORAGE_BASE_KEY = 'sessionId'
+export const EMAIL_STORAGE_BASE_KEY = 'defaultEmail'
+export const EMAIL_ENABLED_STORAGE_BASE_KEY = 'sendSummaryEmails'
+export const DEMO_HISTORY_BASE_KEY = 'demoHistory'
+export const ACTIVE_USER_HANDLE_STORAGE_KEY = 'activeUserHandle'
+export const DEFAULT_NOTIFY_EMAIL = 'a@sarva.co'
+
+const DEFAULT_SCOPE_KEY = '__default__'
+
+export function normalizeHandle(handle?: string | null): string | undefined {
+  if (!handle) return undefined
+  if (typeof handle !== 'string') return undefined
+  const trimmed = handle.trim()
+  if (!trimmed.length) return undefined
+  return trimmed.toLowerCase()
+}
+
+export function deriveUserScopeKey(handle?: string | null): string {
+  return normalizeHandle(handle) ?? DEFAULT_SCOPE_KEY
+}
+
+export function scopedStorageKey(base: string, handle?: string | null): string {
+  const normalized = normalizeHandle(handle)
+  return normalized ? `${base}:${normalized}` : base
+}

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -199,4 +199,27 @@ describe('session deletion helpers', () => {
     const sessions = await data.listSessions()
     expect(sessions).toEqual([])
   })
+
+  it('scopes listing and deletion by user handle', async () => {
+    const data = await import('../lib/data')
+    sendEmailMock.mockResolvedValue({ skipped: true })
+
+    const defaultSession = await data.createSession({ email_to: '' })
+    const handledSession = await data.createSession({ email_to: '', user_handle: 'Amol' })
+
+    const defaultSessions = await data.listSessions()
+    expect(defaultSessions.map((s) => s.id)).toContain(defaultSession.id)
+    expect(defaultSessions.some((s) => s.id === handledSession.id)).toBe(false)
+
+    const scopedSessions = await data.listSessions('amol')
+    expect(scopedSessions.map((s) => s.id)).toEqual([handledSession.id])
+
+    await data.deleteSessionsByHandle('amol')
+
+    const afterDeletionScoped = await data.listSessions('amol')
+    expect(afterDeletionScoped).toEqual([])
+
+    const remainingDefault = await data.listSessions()
+    expect(remainingDefault.map((s) => s.id)).toContain(defaultSession.id)
+  })
 })


### PR DESCRIPTION
## Summary
- Persist normalized user handles on sessions, manifests, and manifest hydration so account-specific data can be queried or deleted safely.
- Filter history APIs/blob lookups by handle and have the UI request and clear history per account, keeping each user’s sessions isolated.
- Refresh the interviewer system prompts to capture the latest guidance on summaries, open-ended questions, and closures.

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfad9f7550832aa5779a5b10394f32