### PR TITLE
Fix history API merge fallout

### DIFF
--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -8,16 +8,17 @@ import {
 } from '@/lib/question-memory'
 import { detectCompletionIntent } from '@/lib/intents'
 
-const SYSTEM_PROMPT = `You are a warm, curious biographer inspired by the professor and book the family mentioned, but you are not following a rigid script.
+const SYSTEM_PROMPT = `You are a warm, curious biographer inspired by the book “The Essential Questions”, but you are not following a rigid script.
 You remember every conversation provided in the memory section below.
 Principles:
 - Follow the user's lead and respond directly to any instruction, question, or aside before you consider another prompt.
 - Be open to any topic the user brings up, gently weaving the discussion back toward the life-story themes when it feels natural.
 - Never repeat or paraphrase the user's own words, and do not repeat questions listed in the memory section.
+- Quickly summarize what you hear in each response before speaking further.
 - If a reply is brief or uncertain, adapt by changing angles or suggesting a different avenue instead of insisting on the same question.
-- Ask at most one short, specific, sensory-rich question (<= 20 words) only when the user seems ready to keep going.
+- Ask at most one short, specific, open-ended question (<= 20 words) only when the user seems ready to keep going.
 - Keep silence handling patient; do not rush to speak if the user pauses briefly.
-- If the user signals they are finished for now, set end_intent to true and close warmly without pushing another question.
+- If the user signals they are finished for now, set end_intent to true and close warmly without pushing another question. Say you are happy to talk more later.
 Return a JSON object: {"reply":"...", "transcript":"...", "end_intent":true|false}.`
 
 function safeJsonParse(input: string | null | undefined) {

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,97 +1,120 @@
 import { NextResponse } from 'next/server'
-import { listSessions, clearAllSessions } from '@/lib/data'
+import { listSessions, clearAllSessions, deleteSessionsByHandle } from '@/lib/data'
 import { fetchStoredSessions } from '@/lib/history'
 import { generateSessionTitle, SummarizableTurn } from '@/lib/session-title'
 
-export async function GET() {
-  const items = await listSessions()
-  const rows = items.map(s => ({
-    id: s.id,
-    created_at: s.created_at,
-    title:
-      s.title ||
-      generateSessionTitle(s.turns, {
-        fallback: `Session on ${new Date(s.created_at).toLocaleDateString()}`,
-      }) ||
-      null,
-    status: s.status,
-    total_turns: s.total_turns,
-    artifacts: {
-      transcript_txt: s.artifacts?.transcript_txt || null,
-      transcript_json: s.artifacts?.transcript_json || null,
+function summarizeUserTurns<T extends { role: string; text?: string | null }>(
+  turns: T[] | undefined,
+): SummarizableTurn[] {
+  if (!turns) return []
+  return turns
+    .filter((turn): turn is T & { text: string } => turn.role === 'user' && typeof turn.text === 'string')
+    .map((turn) => ({ role: 'user' as const, text: turn.text }))
+}
 
-      session_manifest: s.artifacts?.session_manifest || s.artifacts?.manifest || null,
-      session_audio: s.artifacts?.session_audio || null,
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const handle = url.searchParams.get('handle')
 
-    },
-    manifestUrl: s.artifacts?.session_manifest || s.artifacts?.manifest || null,
-    firstAudioUrl: s.turns?.find(t => t.audio_blob_url)?.audio_blob_url || null,
-    sessionAudioUrl: s.artifacts?.session_audio || null,
-  }))
+  const items = await listSessions(handle || undefined)
+  const rows = items.map((session) => {
+    const summarizableTurns = summarizeUserTurns(session.turns)
 
-  const { items: stored } = await fetchStoredSessions({ limit: 50 })
-  for (const session of stored) {
-    if (rows.some(r => r.id === session.sessionId)) continue
-    const summarizableTurns: SummarizableTurn[] = (session.turns || []).flatMap((turn) =>
-      [
-        { role: 'user' as const, text: turn.transcript },
-        turn.assistantReply ? { role: 'assistant' as const, text: turn.assistantReply } : null,
-      ].filter(Boolean) as SummarizableTurn[],
-    )
+    return {
+      id: session.id,
+      created_at: session.created_at,
+      title:
+        session.title ||
+        generateSessionTitle(summarizableTurns, {
+          fallback: `Session on ${new Date(session.created_at).toLocaleDateString()}`,
+        }) ||
+        null,
+      status: session.status,
+      total_turns: session.total_turns,
+      artifacts: {
+        transcript_txt: session.artifacts?.transcript_txt || null,
+        transcript_json: session.artifacts?.transcript_json || null,
+        session_manifest: session.artifacts?.session_manifest || session.artifacts?.manifest || null,
+        session_audio: session.artifacts?.session_audio || null,
+      },
+      manifestUrl: session.artifacts?.session_manifest || session.artifacts?.manifest || null,
+      firstAudioUrl: session.turns?.find((turn) => Boolean(turn.audio_blob_url))?.audio_blob_url || null,
+      sessionAudioUrl: session.artifacts?.session_audio || null,
+    }
+  })
+
+  const { items: stored } = await fetchStoredSessions({ limit: 50, handle: handle || undefined })
+  for (const storedSession of stored) {
+    if (rows.some((row) => row.id === storedSession.sessionId)) continue
+
+    const summarizableTurns: SummarizableTurn[] = (storedSession.turns || [])
+      .filter((turn) => typeof turn?.transcript === 'string')
+      .map((turn) => ({ role: 'user' as const, text: turn.transcript as string }))
 
     rows.push({
-      id: session.sessionId,
-      created_at: session.startedAt || session.endedAt || new Date().toISOString(),
+      id: storedSession.sessionId,
+      created_at: storedSession.startedAt || storedSession.endedAt || new Date().toISOString(),
       title:
         generateSessionTitle(summarizableTurns, {
           fallback: `Session on ${
-            new Date(session.startedAt || session.endedAt || new Date().toISOString()).toLocaleDateString()
+            new Date(
+              storedSession.startedAt || storedSession.endedAt || new Date().toISOString(),
+            ).toLocaleDateString()
           }`,
         }) ||
         null,
       status: 'completed',
-      total_turns: session.totalTurns,
+      total_turns: storedSession.totalTurns,
       artifacts: {
-        transcript_txt: session.artifacts?.transcript_txt || null,
-        transcript_json: session.artifacts?.transcript_json || null,
-
+        transcript_txt: storedSession.artifacts?.transcript_txt || null,
+        transcript_json: storedSession.artifacts?.transcript_json || null,
         session_manifest:
-          session.artifacts?.session_manifest ||
-          session.artifacts?.manifest ||
-          session.manifestUrl ||
+          storedSession.artifacts?.session_manifest ||
+          storedSession.artifacts?.manifest ||
+          storedSession.manifestUrl ||
           null,
-        session_audio: session.artifacts?.session_audio || null,
+        session_audio: storedSession.artifacts?.session_audio || null,
       },
       manifestUrl:
-        session.artifacts?.session_manifest ||
-        session.artifacts?.manifest ||
-        session.manifestUrl ||
+        storedSession.artifacts?.session_manifest ||
+        storedSession.artifacts?.manifest ||
+        storedSession.manifestUrl ||
         null,
-
-      firstAudioUrl: session.turns.find(t => Boolean(t.audio))?.audio || null,
-      sessionAudioUrl: session.artifacts?.session_audio || null,
+      firstAudioUrl: storedSession.turns.find((turn) => Boolean(turn.audio))?.audio || null,
+      sessionAudioUrl: storedSession.artifacts?.session_audio || null,
     })
   }
 
   rows.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+
   // DEMO: merge client-stored demoHistory (if any) as minimal entries
   let demo: any[] = []
   try {
     const raw = (globalThis as any)?.localStorage?.getItem?.('demoHistory')
     if (raw) demo = JSON.parse(raw)
   } catch {}
-  const demoRows = (demo || []).map((d: any) => ({
-    id: d.id,
-    created_at: d.created_at,
-    title: typeof d.title === 'string' && d.title.length ? d.title : null,
+
+  const demoRows = (demo || []).map((entry: any) => ({
+    id: entry.id,
+    created_at: entry.created_at,
+    title: typeof entry.title === 'string' && entry.title.length ? entry.title : null,
     status: 'completed',
     total_turns: 1,
     artifacts: { transcript_txt: null, transcript_json: null },
   }))
+
   return NextResponse.json({ items: [...demoRows, ...rows] })
 }
 
-export async function DELETE() {
+export async function DELETE(request: Request) {
+  const url = new URL(request.url)
+  const handle = url.searchParams.get('handle')
+
+  if (handle) {
+    const result = await deleteSessionsByHandle(handle)
+    return NextResponse.json({ ok: true, deleted: result.deleted, items: [] })
+  }
+
   await clearAllSessions()
   return NextResponse.json({ ok: true, items: [] })
 }

--- a/app/api/session/start/route.ts
+++ b/app/api/session/start/route.ts
@@ -18,10 +18,17 @@ export async function POST(req: NextRequest) {
   const emailsEnabled = payload?.emailsEnabled !== false
   const defaultEmail = process.env.DEFAULT_NOTIFY_EMAIL || 'a@sarva.co'
   const targetEmail = emailsEnabled ? rawEmail || defaultEmail : ''
+  const userHandle =
+    typeof payload?.userHandle === 'string'
+      ? payload.userHandle
+      : typeof payload?.user_handle === 'string'
+      ? payload.user_handle
+      : null
 
   try {
     const session = await createSession({
       email_to: targetEmail,
+      user_handle: userHandle,
     })
     return NextResponse.json({ id: session.id, email: session.email_to, emailsEnabled: emailsEnabled })
   } catch (error: any) {

--- a/app/diagnostics/page.tsx
+++ b/app/diagnostics/page.tsx
@@ -148,56 +148,68 @@ export default function DiagnosticsPage() {
   }
 
   return (
-    <main>
-      <h2 className="text-lg font-semibold mb-3">Diagnostics</h2>
-      <button
-        onClick={runDiagnostics}
-        disabled={isRunning}
-        className="bg-white/10 px-4 py-2 rounded-2xl disabled:opacity-50"
-      >
-        {isRunning ? 'Running…' : 'Run full diagnostics'}
-      </button>
+    <main className="flex flex-col gap-6 text-[rgba(255,247,237,0.9)]">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Diagnostics</h2>
+          <p className="text-xs text-[rgba(255,247,237,0.7)]">Check on our services and keep the interview studio running smoothly.</p>
+        </div>
+        <button
+          onClick={runDiagnostics}
+          disabled={isRunning}
+          className="rounded-full border border-[rgba(249,115,22,0.45)] bg-gradient-to-r from-[#f59e0b] via-[#f97316] to-[#d946ef] px-5 py-2 text-sm font-semibold text-white shadow-[0_15px_45px_rgba(249,115,22,0.35)] transition hover:from-[#f97316] hover:via-[#ec4899] hover:to-[#8b5cf6] disabled:cursor-not-allowed disabled:border-[rgba(255,214,150,0.2)] disabled:bg-[rgba(249,115,22,0.12)] disabled:text-[rgba(255,247,237,0.5)]"
+        >
+          {isRunning ? 'Running…' : 'Run full diagnostics'}
+        </button>
+      </div>
 
-      <div className="mt-4 space-y-3">
-        {TEST_ORDER.map(key => {
+      <div className="space-y-3">
+        {TEST_ORDER.map((key) => {
           const result = results[key]
           return (
-            <div key={key} className="bg-white/5 rounded-xl px-4 py-3">
-              <div className="flex items-center gap-2">
-                <span className="text-xl leading-none">{statusIcon[result.status]}</span>
-                <span className="font-medium">{TEST_CONFIG[key].label}</span>
+            <div
+              key={key}
+              className="rounded-3xl border border-[rgba(156,163,255,0.3)] bg-[rgba(24,9,42,0.7)] px-4 py-4 shadow-[0_15px_50px_rgba(91,33,182,0.25)]"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-xl leading-none text-[rgba(255,247,237,0.9)]">{statusIcon[result.status]}</span>
+                <span className="text-sm font-semibold text-white">{TEST_CONFIG[key].label}</span>
               </div>
               {result.message && (
-                <div className="mt-1 text-sm opacity-80 whitespace-pre-wrap">{result.message}</div>
+                <div className="mt-2 text-sm text-[rgba(255,247,237,0.78)] whitespace-pre-wrap">{result.message}</div>
               )}
             </div>
           )
         })}
       </div>
 
+      <label className="mt-2 text-xs uppercase tracking-[0.4em] text-[rgba(255,247,237,0.6)]">Log output</label>
       <textarea
         value={log}
         readOnly
-        className="mt-4 w-full h-96 bg-black/30 p-2 rounded"
+        className="h-80 w-full rounded-3xl border border-[rgba(156,163,255,0.35)] bg-[rgba(10,4,24,0.8)] p-4 text-sm leading-relaxed text-[rgba(255,247,237,0.82)] shadow-[0_15px_60px_rgba(91,33,182,0.3)]"
       />
 
-      <div className="mt-4">
-        <h3 className="font-semibold mb-2">Tracked foxes</h3>
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold text-white">Tracked foxes</h3>
         {foxes.length === 0 ? (
-          <p className="text-sm opacity-70">No foxes have been triggered yet.</p>
+          <p className="text-sm text-[rgba(255,247,237,0.7)]">No foxes have been triggered yet.</p>
         ) : (
-          <ul className="space-y-2 text-sm">
-            {foxes.map(fox => (
-              <li key={fox.id} className="bg-white/5 rounded-xl px-3 py-2">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-medium">Theory {fox.theory} – {fox.message}</span>
-                  <span className="text-xs uppercase tracking-wide opacity-70">{fox.level}</span>
+          <ul className="space-y-3 text-sm">
+            {foxes.map((fox) => (
+              <li
+                key={fox.id}
+                className="rounded-3xl border border-[rgba(249,115,22,0.35)] bg-[rgba(33,12,53,0.75)] px-4 py-3 shadow-[0_15px_50px_rgba(249,115,22,0.25)]"
+              >
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <span className="font-medium text-white">Theory {fox.theory} – {fox.message}</span>
+                  <span className="text-xs uppercase tracking-wide text-[rgba(255,247,237,0.65)]">{fox.level}</span>
                 </div>
-                <div className="text-xs opacity-70 mt-1">
+                <div className="mt-1 text-xs text-[rgba(255,247,237,0.65)]">
                   Count: {fox.count} · Last: {new Date(fox.lastTriggeredAt).toLocaleString()}
                 </div>
                 {fox.details && (
-                  <pre className="mt-2 text-xs bg-black/40 p-2 rounded whitespace-pre-wrap">
+                  <pre className="mt-2 rounded-2xl bg-[rgba(10,4,24,0.85)] p-3 text-xs text-[rgba(255,247,237,0.8)] whitespace-pre-wrap">
                     {JSON.stringify(fox.details, null, 2)}
                   </pre>
                 )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,55 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-:root { --bg: #0b0c10; --fg: #e5e7eb; }
-html, body { height: 100%; }
-body { background: var(--bg); color: var(--fg); }
-button { @apply rounded-2xl px-4 py-2 font-medium; }
+:root {
+  --bg-gradient: radial-gradient(circle at 20% -10%, rgba(255, 214, 150, 0.5), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(186, 104, 200, 0.45), transparent 50%),
+    linear-gradient(135deg, #1a1032 0%, #261046 35%, #431b63 68%, #190b2d 100%);
+  --bg-overlay: radial-gradient(circle at 50% 120%, rgba(255, 140, 66, 0.35), transparent 70%);
+  --fg: #fff7ed;
+  --card: rgba(33, 12, 53, 0.78);
+  --card-border: rgba(255, 244, 214, 0.14);
+  --muted: rgba(255, 247, 237, 0.75);
+  --accent: #f59e0b;
+  --accent-strong: #f97316;
+  --deep-purple: #5b21b6;
+}
+html,
+body {
+  height: 100%;
+}
+body {
+  background: var(--bg-gradient);
+  color: var(--fg);
+  font-family: 'Inter', 'Noto Sans', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  position: relative;
+  overflow-x: hidden;
+}
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  inset: -10%;
+  pointer-events: none;
+  background: var(--bg-overlay);
+  opacity: 0.75;
+  mix-blend-mode: screen;
+  filter: blur(18px);
+  z-index: -2;
+}
+body::after {
+  inset: auto;
+  top: 25%;
+  right: -30%;
+  bottom: -20%;
+  left: auto;
+  background: radial-gradient(circle at 30% 30%, rgba(245, 158, 11, 0.3), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(91, 33, 182, 0.28), transparent 65%);
+  opacity: 0.6;
+}
+button {
+  @apply rounded-2xl px-4 py-2 font-medium;
+}
 textarea { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
 a { text-underline-offset: 2px; }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,29 +30,86 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="en">
-      <body className="min-h-screen">
-        <div className="max-w-3xl mx-auto px-4 py-6">
-          <header className="flex items-center justify-between mb-6">
-            <h1 className="text-xl font-semibold">Dad&apos;s Interview Bot</h1>
-            <nav className="space-x-4 text-sm opacity-90">
-              <a href="/" className="underline">Home</a>
-              <a href="/history" className="underline">History</a>
-              <a href="/settings" className="underline">Settings</a>
-              <a href="/diagnostics" className="underline">Diagnostics</a>
-            </nav>
+      <body className="min-h-screen text-[var(--fg)] antialiased">
+        <div className="pointer-events-none fixed inset-x-0 top-0 flex justify-center gap-10 px-8 pt-12 text-4xl text-amber-200/80 sm:text-5xl">
+          <span className="drop-shadow-[0_0_18px_rgba(249,196,79,0.55)]" aria-hidden>
+            🪔
+          </span>
+          <span className="drop-shadow-[0_0_18px_rgba(129,140,248,0.45)]" aria-hidden>
+            🪷
+          </span>
+          <span className="drop-shadow-[0_0_20px_rgba(236,72,153,0.4)]" aria-hidden>
+            🫖
+          </span>
+        </div>
+        <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-8 px-4 py-12 sm:px-8">
+          <header className="relative overflow-hidden rounded-[32px] border border-[rgba(255,244,214,0.14)] bg-[rgba(33,12,53,0.82)] px-6 py-6 shadow-[0_25px_80px_rgba(120,45,110,0.35)] backdrop-blur-xl sm:px-10">
+            <div
+              className="pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-[rgba(249,196,79,0.1)] to-[rgba(91,33,182,0.25)]"
+              aria-hidden
+            />
+            <div className="relative flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+              <div className="max-w-xl">
+                <p className="text-xs uppercase tracking-[0.5em] text-[rgba(255,247,237,0.6)]">Story Studio</p>
+                <h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">Dad&apos;s Interview Bot</h1>
+                <p className="mt-3 text-sm leading-relaxed text-[rgba(255,247,237,0.72)]">
+                  A warm, colourful space for capturing the stories that make your family shine. Settle in with a cup of chai and let the conversation flow.
+                </p>
+              </div>
+              <nav className="flex flex-wrap items-center gap-2 text-sm">
+                {[
+                  { href: '/', label: 'Home' },
+                  { href: '/history', label: 'History' },
+                  { href: '/settings', label: 'Settings' },
+                  { href: '/diagnostics', label: 'Diagnostics' },
+                ].map((item) => (
+                  <a
+                    key={item.href}
+                    href={item.href}
+                    className="group relative overflow-hidden rounded-full border border-[rgba(255,214,150,0.35)] bg-[rgba(251,191,36,0.08)] px-4 py-2 font-medium text-[rgba(255,247,237,0.85)] transition hover:border-[rgba(249,115,22,0.5)] hover:bg-[rgba(249,115,22,0.16)] hover:text-white"
+                  >
+                    <span className="absolute inset-0 translate-y-full bg-gradient-to-r from-[rgba(249,115,22,0.35)] via-[rgba(217,70,239,0.2)] to-[rgba(129,140,248,0.35)] transition-transform duration-300 ease-out group-hover:translate-y-0" aria-hidden />
+                    <span className="relative">{item.label}</span>
+                  </a>
+                ))}
+              </nav>
+            </div>
           </header>
-          {children}
-          <footer className="mt-10 text-xs opacity-70">
-            {commitUrl ? (
-              <a href={commitUrl} className="underline">
-                {shortSha} — {commitMessage}
-              </a>
-            ) : (
-              <span>
-                {shortSha} — {commitMessage}
-              </span>
-            )}{' '}
-            · {formattedTime}
+
+          <div className="relative flex-1">
+            <div className="relative overflow-hidden rounded-[36px] border border-[rgba(255,244,214,0.14)] bg-[rgba(33,12,53,0.86)] px-5 py-8 shadow-[0_30px_90px_rgba(120,45,110,0.35)] backdrop-blur-xl sm:px-12 sm:py-12">
+              <div
+                className="pointer-events-none absolute inset-0 opacity-80"
+                style={{
+                  background:
+                    'radial-gradient(circle at 12% 20%, rgba(249, 196, 79, 0.18), transparent 60%), radial-gradient(circle at 88% 14%, rgba(217, 70, 239, 0.16), transparent 55%), radial-gradient(circle at 35% 80%, rgba(56, 189, 248, 0.12), transparent 60%)',
+                }}
+                aria-hidden
+              />
+              <div className="relative">{children}</div>
+            </div>
+          </div>
+
+          <footer className="relative overflow-hidden rounded-[28px] border border-[rgba(255,244,214,0.14)] bg-[rgba(33,12,53,0.78)] px-6 py-4 text-xs text-[rgba(255,247,237,0.7)] shadow-[0_18px_60px_rgba(120,45,110,0.3)] backdrop-blur-xl sm:px-10">
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-[rgba(249,196,79,0.08)] to-[rgba(91,33,182,0.18)]" aria-hidden />
+            <div className="relative flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                {commitUrl ? (
+                  <a href={commitUrl} className="underline">
+                    {shortSha} — {commitMessage}
+                  </a>
+                ) : (
+                  <span>
+                    {shortSha} — {commitMessage}
+                  </span>
+                )}{' '}
+                · {formattedTime}
+              </div>
+              <div className="flex items-center gap-2 text-[rgba(255,247,237,0.7)]">
+                <span aria-hidden>🪔</span>
+                <span>Crafted with warmth for every family gathering.</span>
+              </div>
+            </div>
           </footer>
         </div>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,11 +5,18 @@ import { calibrateRMS, recordUntilSilence, blobToBase64 } from '@/lib/audio-brid
 import { createSessionRecorder, SessionRecorder } from '@/lib/session-recorder'
 import { generateSessionTitle, SummarizableTurn } from '@/lib/session-title'
 import { detectCompletionIntent } from '@/lib/intents'
+import {
+  ACTIVE_USER_HANDLE_STORAGE_KEY,
+  DEFAULT_NOTIFY_EMAIL,
+  DEMO_HISTORY_BASE_KEY,
+  EMAIL_ENABLED_STORAGE_BASE_KEY,
+  EMAIL_STORAGE_BASE_KEY,
+  SESSION_STORAGE_BASE_KEY,
+  deriveUserScopeKey,
+  normalizeHandle,
+  scopedStorageKey,
+} from '@/lib/user-scope'
 
-const SESSION_STORAGE_KEY = 'sessionId'
-const EMAIL_STORAGE_KEY = 'defaultEmail'
-const EMAIL_ENABLED_KEY = 'sendSummaryEmails'
-const DEFAULT_NOTIFY_EMAIL = 'a@sarva.co'
 const HARD_TURN_LIMIT_MS = 90_000
 const DEFAULT_BASELINE = 0.004
 const MIN_BASELINE = 0.0004
@@ -24,6 +31,10 @@ const clampBaseline = (value: number | null | undefined) => {
   return clamped
 }
 
+export default function RootPage() {
+  return <Home key="__default__" />
+}
+
 type SessionInitSource = 'memory' | 'storage' | 'network' | 'fallback'
 
 type SessionInitResult = {
@@ -36,8 +47,22 @@ type NetworkSessionResult = {
   source: Extract<SessionInitSource, 'network' | 'fallback'>
 }
 
-let inMemorySessionId: string | null = null
-let sessionStartPromise: Promise<NetworkSessionResult> | null = null
+type ScopedSessionState = {
+  inMemorySessionId: string | null
+  sessionStartPromise: Promise<NetworkSessionResult> | null
+}
+
+const scopedSessionStates = new Map<string, ScopedSessionState>()
+
+function getScopedSessionState(handle?: string | null) {
+  const key = deriveUserScopeKey(handle)
+  let state = scopedSessionStates.get(key)
+  if (!state) {
+    state = { inMemorySessionId: null, sessionStartPromise: null }
+    scopedSessionStates.set(key, state)
+  }
+  return { key, state }
+}
 
 const createLocalSessionId = () => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -46,30 +71,34 @@ const createLocalSessionId = () => {
   return Math.random().toString(36).slice(2)
 }
 
-const readStoredSessionId = () => {
+const readStoredSessionId = (handle?: string | null) => {
   if (typeof window === 'undefined') return null
   try {
-    const stored = window.sessionStorage.getItem(SESSION_STORAGE_KEY)
+    const key = scopedStorageKey(SESSION_STORAGE_BASE_KEY, handle)
+    const stored = window.sessionStorage.getItem(key)
     return stored && typeof stored === 'string' ? stored : null
   } catch {
     return null
   }
 }
 
-const persistSessionId = (id: string) => {
+const persistSessionId = (id: string, handle?: string | null) => {
   if (typeof window === 'undefined') return
   try {
-    window.sessionStorage.setItem(SESSION_STORAGE_KEY, id)
+    const key = scopedStorageKey(SESSION_STORAGE_BASE_KEY, handle)
+    window.sessionStorage.setItem(key, id)
   } catch {}
 }
 
-const readEmailPreferences = () => {
+const readEmailPreferences = (handle?: string | null) => {
   if (typeof window === 'undefined') {
     return { email: DEFAULT_NOTIFY_EMAIL, emailsEnabled: true }
   }
   try {
-    const email = window.localStorage.getItem(EMAIL_STORAGE_KEY) || DEFAULT_NOTIFY_EMAIL
-    const rawEnabled = window.localStorage.getItem(EMAIL_ENABLED_KEY)
+    const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, handle)
+    const email = window.localStorage.getItem(emailKey) || DEFAULT_NOTIFY_EMAIL
+    const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, handle)
+    const rawEnabled = window.localStorage.getItem(enabledKey)
     const emailsEnabled = rawEnabled === null ? true : rawEnabled !== 'false'
     return { email, emailsEnabled }
   } catch {
@@ -77,55 +106,61 @@ const readEmailPreferences = () => {
   }
 }
 
-const requestNewSessionId = async (): Promise<NetworkSessionResult> => {
+const requestNewSessionId = async (handle?: string | null): Promise<NetworkSessionResult> => {
+  const { state } = getScopedSessionState(handle)
+
   if (typeof window === 'undefined') {
     const fallbackId = createLocalSessionId()
+    state.inMemorySessionId = fallbackId
     return { id: fallbackId, source: 'fallback' as const }
   }
 
   try {
-    const { email, emailsEnabled } = readEmailPreferences()
+    const { email, emailsEnabled } = readEmailPreferences(handle)
     const res = await fetch('/api/session/start', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ email, emailsEnabled }),
+      body: JSON.stringify({ email, emailsEnabled, userHandle: normalizeHandle(handle) ?? null }),
     })
     const data = await res.json().catch(() => ({}))
     const id = typeof data?.id === 'string' && data.id ? data.id : createLocalSessionId()
     const source: NetworkSessionResult['source'] =
       typeof data?.id === 'string' && data.id ? 'network' : 'fallback'
-    inMemorySessionId = id
-    persistSessionId(id)
+    state.inMemorySessionId = id
+    persistSessionId(id, handle)
     return { id, source }
   } catch {
-    let id = readStoredSessionId()
+    let id = readStoredSessionId(handle)
     if (!id) {
       id = createLocalSessionId()
     }
-    inMemorySessionId = id
-    persistSessionId(id)
+    state.inMemorySessionId = id
+    persistSessionId(id, handle)
     return { id, source: 'fallback' as const }
   }
 }
 
-const ensureSessionIdOnce = async (): Promise<SessionInitResult> => {
-  if (inMemorySessionId) {
-    return { id: inMemorySessionId, source: 'memory' }
+const ensureSessionIdOnce = async (handle?: string | null): Promise<SessionInitResult> => {
+  const { state } = getScopedSessionState(handle)
+
+  if (state.inMemorySessionId) {
+    return { id: state.inMemorySessionId, source: 'memory' }
   }
 
-  const stored = readStoredSessionId()
+  const stored = readStoredSessionId(handle)
   if (stored) {
-    inMemorySessionId = stored
+    state.inMemorySessionId = stored
     return { id: stored, source: 'storage' }
   }
 
-  if (!sessionStartPromise) {
-    sessionStartPromise = requestNewSessionId().finally(() => {
-      sessionStartPromise = null
+  if (!state.sessionStartPromise) {
+    state.sessionStartPromise = requestNewSessionId(handle).finally(() => {
+      const current = getScopedSessionState(handle).state
+      current.sessionStartPromise = null
     })
   }
 
-  const result = await sessionStartPromise
+  const result = await state.sessionStartPromise
   return result
 }
 
@@ -148,56 +183,56 @@ const STATE_VISUALS: Record<
     badge: 'Ready',
     title: 'Ready to begin',
     description: 'I’ll start the conversation for you—just settle in and listen.',
-    gradient: 'from-sky-400/40 via-blue-500/30 to-indigo-500/40',
+    gradient: 'from-[#f59e0b]/45 via-[#f97316]/45 to-[#d946ef]/40',
   },
   calibrating: {
     icon: '🎚️',
     badge: 'Preparing',
     title: 'Getting ready to listen',
     description: 'Give me a moment to measure the room noise before I start recording.',
-    gradient: 'from-cyan-400/40 via-sky-400/40 to-indigo-400/40',
+    gradient: 'from-[#fcd34d]/45 via-[#fb923c]/40 to-[#f97316]/45',
   },
   recording: {
     icon: '🎤',
     badge: 'Listening',
     title: 'Listening',
     description: 'I’m capturing every detail you say. Speak naturally and tap the ring when you’d like me to stop listening.',
-    gradient: 'from-emerald-400/40 via-lime-300/40 to-emerald-500/40',
+    gradient: 'from-[#f97316]/45 via-[#facc15]/40 to-[#f59e0b]/45',
   },
   thinking: {
     icon: '🤔',
     badge: 'Thinking',
     title: 'Thinking',
     description: 'Give me a brief moment while I make sense of what you shared.',
-    gradient: 'from-fuchsia-400/40 via-purple-500/40 to-indigo-600/40',
+    gradient: 'from-[#d946ef]/45 via-[#a855f7]/40 to-[#7c3aed]/45',
   },
   speakingPrep: {
     icon: '🔄',
     badge: 'Warming up',
     title: 'Preparing to speak',
     description: 'Spinning up my voice so I can respond clearly.',
-    gradient: 'from-amber-300/40 via-amber-400/40 to-orange-500/40',
+    gradient: 'from-[#fb923c]/45 via-[#f97316]/45 to-[#ef4444]/40',
   },
   playing: {
     icon: '💬',
     badge: 'Speaking',
     title: 'Speaking',
     description: 'Sharing what I heard and how we can keep going.',
-    gradient: 'from-amber-400/40 via-orange-500/40 to-amber-600/40',
+    gradient: 'from-[#f97316]/45 via-[#f472b6]/40 to-[#7c3aed]/45',
   },
   readyToContinue: {
     icon: '✨',
     badge: 'Ready',
     title: 'Ready for more',
     description: 'Just start speaking whenever you’re ready for the next part.',
-    gradient: 'from-sky-400/40 via-cyan-400/40 to-blue-500/40',
+    gradient: 'from-[#fbbf24]/45 via-[#f97316]/45 to-[#a855f7]/40',
   },
   doneSuccess: {
     icon: '✅',
     badge: 'Complete',
     title: 'Session complete',
     description: 'Review your links or start another memory when you feel inspired.',
-    gradient: 'from-slate-400/40 via-slate-500/40 to-slate-600/40',
+    gradient: 'from-[#34d399]/35 via-[#38bdf8]/35 to-[#6366f1]/35',
   },
 }
 
@@ -207,7 +242,9 @@ type AssistantPlayback = {
   durationMs: number
 }
 
-export default function Home() {
+export function Home({ userHandle }: { userHandle?: string }) {
+  const normalizedHandle = normalizeHandle(userHandle)
+  const displayHandle = userHandle?.trim() || null
   const machineState = useInterviewMachine((state) => state.state)
   const debugLog = useInterviewMachine((state) => state.debugLog)
   const pushLog = useInterviewMachine((state) => state.pushLog)
@@ -226,6 +263,7 @@ export default function Home() {
   const finishRequestedRef = useRef(false)
   const sessionInitRef = useRef(false)
   const lastAnnouncedSessionIdRef = useRef<string | null>(null)
+  const lastLoggedHandleRef = useRef<string | null>(null)
   const conversationRef = useRef<SummarizableTurn[]>([])
   const autoAdvanceTimeoutRef = useRef<number | null>(null)
 
@@ -253,13 +291,32 @@ export default function Home() {
   }, [finishRequested])
 
   useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (normalizedHandle) {
+      window.localStorage.setItem(ACTIVE_USER_HANDLE_STORAGE_KEY, normalizedHandle)
+    } else {
+      window.localStorage.removeItem(ACTIVE_USER_HANDLE_STORAGE_KEY)
+    }
+  }, [normalizedHandle])
+
+  useEffect(() => {
+    if (!normalizedHandle) {
+      lastLoggedHandleRef.current = null
+      return
+    }
+    if (lastLoggedHandleRef.current === normalizedHandle) return
+    lastLoggedHandleRef.current = normalizedHandle
+    pushLog(`Viewing account: /u/${normalizedHandle}`)
+  }, [normalizedHandle, pushLog])
+
+  useEffect(() => {
     if (sessionInitRef.current) return
     sessionInitRef.current = true
     if (typeof window === 'undefined') return
 
     let cancelled = false
 
-    ensureSessionIdOnce()
+    ensureSessionIdOnce(normalizedHandle)
       .then((result) => {
         if (cancelled) return
         setSessionId(result.id)
@@ -278,8 +335,9 @@ export default function Home() {
       .catch(() => {
         if (cancelled) return
         const fallbackId = createLocalSessionId()
-        inMemorySessionId = fallbackId
-        persistSessionId(fallbackId)
+        const { state } = getScopedSessionState(normalizedHandle)
+        state.inMemorySessionId = fallbackId
+        persistSessionId(fallbackId, normalizedHandle)
         setSessionId(fallbackId)
         if (lastAnnouncedSessionIdRef.current !== fallbackId) {
           lastAnnouncedSessionIdRef.current = fallbackId
@@ -290,7 +348,7 @@ export default function Home() {
     return () => {
       cancelled = true
     }
-  }, [pushLog])
+  }, [normalizedHandle, pushLog])
 
   useEffect(() => {
     return () => {
@@ -517,7 +575,7 @@ export default function Home() {
       sessionAudioUrlRef.current = sessionAudioUrl
       sessionAudioDurationRef.current = sessionAudioDurationMs
 
-      const { email: preferredEmail, emailsEnabled } = readEmailPreferences()
+      const { email: preferredEmail, emailsEnabled } = readEmailPreferences(normalizedHandle)
       const trimmedEmail = preferredEmail && preferredEmail.trim().length ? preferredEmail.trim() : undefined
       const emailForSession = emailsEnabled ? trimmedEmail : undefined
 
@@ -604,14 +662,15 @@ export default function Home() {
       if (!memOk) throw new Error('Finalize failed')
 
       try {
-        const demo = JSON.parse(localStorage.getItem('demoHistory') || '[]')
+        const historyKey = scopedStorageKey(DEMO_HISTORY_BASE_KEY, normalizedHandle)
+        const demo = JSON.parse(localStorage.getItem(historyKey) || '[]')
         const stamp = new Date().toISOString()
         const summaryTitle =
           generateSessionTitle(conversationRef.current, {
             fallback: `Session on ${new Date(stamp).toLocaleDateString()}`,
           }) || null
         demo.unshift({ id: sessionId, created_at: stamp, title: summaryTitle })
-        localStorage.setItem('demoHistory', JSON.stringify(demo.slice(0, 50)))
+        localStorage.setItem(historyKey, JSON.stringify(demo.slice(0, 50)))
       } catch {}
 
       toDone()
@@ -623,7 +682,7 @@ export default function Home() {
       finishRequestedRef.current = false
       setFinishRequested(false)
     }
-  }, [pushLog, sessionId, toDone, updateMachineState])
+  }, [normalizedHandle, pushLog, sessionId, toDone, updateMachineState])
 
   const requestManualStop = useCallback(() => {
     if (!inTurnRef.current) return
@@ -727,6 +786,7 @@ export default function Home() {
 
       const completionIntent = detectCompletionIntent(transcript)
       const completionDetected = completionIntent.shouldStop && completionIntent.confidence !== 'low'
+      const providerSuggestedStop = endIntent === true
       if (completionIntent.shouldStop) {
         const match = completionIntent.matchedPhrases.join(', ')
         const suffix = match.length ? `: ${match}` : ''
@@ -801,8 +861,12 @@ export default function Home() {
 
       pushLog('Finished playing → ready')
       const reachedMax = nextTurn >= MAX_TURNS
+      if (providerSuggestedStop && !completionDetected && !finishRequestedRef.current) {
+        pushLog('Provider end intent ignored—no user stop detected')
+      }
+
       const shouldEnd =
-        finishRequestedRef.current || endIntent || reachedMax || completionDetected
+        finishRequestedRef.current || reachedMax || completionDetected
       inTurnRef.current = false
 
       if (shouldEnd) {
@@ -1059,25 +1123,31 @@ export default function Home() {
   })()
 
   return (
-    <main className="mt-6 flex justify-center px-4 pb-16">
+    <main className="flex w-full flex-col items-center gap-12 pb-6">
       <div className="flex w-full max-w-4xl flex-col items-center gap-12">
-        <div className="flex w-full flex-col items-center gap-8">
-          <div className="relative w-full max-w-[min(90vw,460px)]">
+        <div className="flex w-full flex-col items-center gap-9">
+          {displayHandle && (
+            <div className="inline-flex items-center gap-2 rounded-full border border-[rgba(255,214,150,0.3)] bg-[rgba(251,191,36,0.12)] px-4 py-1 text-sm text-[rgba(255,247,237,0.85)]">
+              <span aria-hidden>🪔</span>
+              Account <span className="font-semibold text-white">@{displayHandle.toLowerCase()}</span>
+            </div>
+          )}
+          <div className="relative w-full max-w-[min(92vw,480px)]">
             <button
               type="button"
               onClick={handleHeroPress}
-              className="group relative aspect-square w-full overflow-hidden rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/60"
+              className="group relative aspect-square w-full overflow-hidden rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[rgba(251,191,36,0.6)]"
               aria-label={heroAriaLabel}
             >
-              <span className="absolute inset-0 rounded-full bg-black/20 blur-3xl" aria-hidden="true" />
+              <span className="absolute inset-0 rounded-full bg-[rgba(249,115,22,0.22)] blur-3xl" aria-hidden="true" />
               <span
-                className={`absolute inset-[8%] rounded-full bg-gradient-to-br ${heroGradient} animate-soft-pulse shadow-[0_0_80px_rgba(255,255,255,0.18)]`}
+                className={`absolute inset-[8%] rounded-full bg-gradient-to-br ${heroGradient} animate-soft-pulse shadow-[0_0_90px_rgba(249,196,79,0.35)]`}
                 aria-hidden="true"
               />
-              <span className="absolute inset-[12%] rounded-full border border-white/15 bg-black/50 backdrop-blur-sm" aria-hidden="true" />
-              <span className="absolute inset-[18%] rounded-full border border-white/10 animate-slow-ripple" aria-hidden="true" />
+              <span className="absolute inset-[12%] rounded-full border border-[rgba(255,247,237,0.22)] bg-[rgba(30,12,48,0.65)] backdrop-blur" aria-hidden="true" />
+              <span className="absolute inset-[18%] rounded-full border border-[rgba(255,214,150,0.35)] animate-slow-ripple" aria-hidden="true" />
               <span
-                className="absolute inset-[18%] rounded-full border border-white/5 animate-slow-ripple"
+                className="absolute inset-[18%] rounded-full border border-[rgba(217,70,239,0.35)] animate-slow-ripple"
                 style={{ animationDelay: '1.2s' }}
                 aria-hidden="true"
               />
@@ -1085,15 +1155,15 @@ export default function Home() {
                 <span className="text-5xl md:text-6xl" aria-hidden="true">
                   {heroIcon}
                 </span>
-                <span className="mt-4 text-[11px] uppercase tracking-[0.45em] text-white/50">{heroBadge}</span>
-                <span className="mt-3 text-3xl font-semibold md:text-4xl">{heroTitle}</span>
-                <span className="mt-4 text-sm text-white/70 md:text-base">{heroDescription}</span>
+                <span className="mt-4 text-[11px] uppercase tracking-[0.45em] text-[rgba(255,247,237,0.65)]">{heroBadge}</span>
+                <span className="mt-3 text-3xl font-semibold text-white md:text-4xl">{heroTitle}</span>
+                <span className="mt-4 text-sm text-[rgba(255,247,237,0.78)] md:text-base">{heroDescription}</span>
               </span>
             </button>
           </div>
 
           <div className="flex flex-col items-center gap-4 text-center">
-            <div className="text-sm text-white/70">{statusMessage}</div>
+            <div className="text-sm text-[rgba(255,247,237,0.8)]">{statusMessage}</div>
             {machineState === 'doneSuccess' ? (
               <button
                 onClick={() => {
@@ -1112,7 +1182,7 @@ export default function Home() {
                   setManualStopRequested(false)
                   updateMachineState('idle')
                 }}
-                className="rounded-full bg-white px-8 py-3 text-lg font-semibold text-black shadow-lg transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                className="rounded-full bg-gradient-to-r from-[#f59e0b] via-[#f97316] to-[#d946ef] px-10 py-3 text-lg font-semibold text-white shadow-[0_20px_45px_rgba(249,115,22,0.35)] transition hover:from-[#f97316] hover:via-[#ec4899] hover:to-[#8b5cf6] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[rgba(249,196,79,0.6)]"
               >
                 Start Again
               </button>
@@ -1121,7 +1191,7 @@ export default function Home() {
               <button
                 onClick={requestFinish}
                 disabled={!hasStarted || finishRequested}
-                className="rounded-full border border-white/20 bg-white/5 px-5 py-2 text-sm font-medium text-white/80 transition hover:border-white/40 hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
+                className="rounded-full border border-[rgba(255,214,150,0.35)] bg-[rgba(33,12,53,0.6)] px-5 py-2 text-sm font-medium text-[rgba(255,247,237,0.85)] transition hover:border-[rgba(249,115,22,0.6)] hover:bg-[rgba(249,115,22,0.18)] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-3 focus-visible:outline-[rgba(249,196,79,0.45)] disabled:cursor-not-allowed disabled:border-[rgba(255,214,150,0.2)] disabled:text-[rgba(255,247,237,0.4)]"
               >
                 I’m finished
               </button>
@@ -1130,20 +1200,20 @@ export default function Home() {
         </div>
 
         <div className="w-full max-w-2xl">
-          <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.4em] text-white/40">
+          <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.4em] text-[rgba(255,247,237,0.5)]">
             <span>Diagnostics log</span>
-            <a className="text-xs font-medium uppercase tracking-[0.2em] text-white/50 underline hover:text-white/80" href="/diagnostics">
+            <a className="text-xs font-medium uppercase tracking-[0.2em] text-[rgba(255,247,237,0.7)] underline decoration-[rgba(255,247,237,0.4)] transition hover:text-white" href="/diagnostics">
               Open
             </a>
           </div>
           <textarea
             value={debugLog.join('\n')}
             readOnly
-            className="mt-2 h-28 w-full resize-none rounded border border-white/10 bg-black/30 p-3 text-[11px] leading-relaxed text-white/70"
+            className="mt-3 h-32 w-full resize-none rounded-2xl border border-[rgba(255,214,150,0.25)] bg-[rgba(16,7,32,0.7)] p-4 text-[11px] leading-relaxed text-[rgba(255,247,237,0.8)] shadow-[0_18px_45px_rgba(120,45,110,0.25)]"
           />
-          <div className="mt-1 text-[11px] text-white/40">
+          <div className="mt-2 text-[11px] text-[rgba(255,247,237,0.62)]">
             Need more detail?{' '}
-            <a className="underline hover:text-white/80" href="/diagnostics">
+            <a className="underline decoration-[rgba(255,247,237,0.4)] transition hover:text-white" href="/diagnostics">
               Visit Diagnostics
             </a>
             .

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,15 +1,40 @@
-'use client'
+"use client"
 import { useState, useEffect } from 'react'
+import {
+  ACTIVE_USER_HANDLE_STORAGE_KEY,
+  DEFAULT_NOTIFY_EMAIL,
+  EMAIL_ENABLED_STORAGE_BASE_KEY,
+  EMAIL_STORAGE_BASE_KEY,
+  normalizeHandle,
+  scopedStorageKey,
+} from '@/lib/user-scope'
 
 export default function SettingsPage() {
   const [email, setEmail] = useState('')
   const [sendEmails, setSendEmails] = useState(true)
   const [saved, setSaved] = useState(false)
+  const [activeHandle, setActiveHandle] = useState<string | undefined>(undefined)
 
   useEffect(() => {
-    setEmail(localStorage.getItem('defaultEmail') || 'a@sarva.co')
-    const raw = localStorage.getItem('sendSummaryEmails')
-    setSendEmails(raw === null ? true : raw !== 'false')
+    if (typeof window === 'undefined') {
+      setEmail(DEFAULT_NOTIFY_EMAIL)
+      setSendEmails(true)
+      setActiveHandle(undefined)
+      return
+    }
+    try {
+      const storedHandle = normalizeHandle(window.localStorage.getItem(ACTIVE_USER_HANDLE_STORAGE_KEY))
+      setActiveHandle(storedHandle)
+      const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, storedHandle)
+      setEmail(window.localStorage.getItem(emailKey) || DEFAULT_NOTIFY_EMAIL)
+      const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, storedHandle)
+      const raw = window.localStorage.getItem(enabledKey)
+      setSendEmails(raw === null ? true : raw !== 'false')
+    } catch {
+      setEmail(DEFAULT_NOTIFY_EMAIL)
+      setSendEmails(true)
+      setActiveHandle(undefined)
+    }
   }, [])
 
   useEffect(() => {
@@ -17,29 +42,53 @@ export default function SettingsPage() {
   }, [email, sendEmails])
 
   return (
-    <main>
-      <h2 className="text-lg font-semibold mb-4">Settings</h2>
-      <label className="block text-sm mb-1">Default notify email</label>
-      <input value={email} onChange={e=>setEmail(e.target.value)} className="bg-white/10 rounded p-2 w-full max-w-md" />
-      <label className="flex items-center gap-2 text-sm mt-4">
-        <input
-          type="checkbox"
-          checked={sendEmails}
-          onChange={e => setSendEmails(e.target.checked)}
-        />
-        <span>Send session summaries by email</span>
-      </label>
-      <div className="mt-3">
-        <button
-          onClick={()=>{
-            localStorage.setItem('defaultEmail', email)
-            localStorage.setItem('sendSummaryEmails', sendEmails ? 'true' : 'false')
-            setSaved(true)
-          }}
-          className="bg-white/10 px-4 py-1 rounded"
-        >Save</button>
-        {saved && <span className="text-xs ml-3 opacity-70">Saved.</span>}
+    <main className="flex flex-col gap-6 text-[rgba(255,247,237,0.9)]">
+      <div>
+        <h2 className="text-2xl font-semibold text-white">Settings</h2>
+        {activeHandle && (
+          <p className="mt-1 text-xs text-[rgba(255,247,237,0.7)]">
+            Active account: <span className="font-semibold text-white">@{activeHandle}</span>
+          </p>
+        )}
       </div>
+      <section className="rounded-3xl border border-[rgba(255,214,150,0.28)] bg-[rgba(24,9,42,0.72)] p-6 shadow-[0_18px_60px_rgba(120,45,110,0.28)]">
+        <p className="text-sm text-[rgba(255,247,237,0.75)]">
+          Personalize how we keep in touch after each interview. All settings stay linked to your handle, so every family member can choose what feels right.
+        </p>
+        <div className="mt-5 space-y-4">
+          <label className="block text-sm font-medium text-white/90">Default notify email</label>
+          <input
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full max-w-md rounded-2xl border border-[rgba(156,163,255,0.35)] bg-[rgba(10,4,24,0.85)] px-4 py-2 text-[rgba(255,247,237,0.92)] shadow-[0_10px_35px_rgba(91,33,182,0.25)] focus:outline-none focus:ring-2 focus:ring-[rgba(249,115,22,0.45)]"
+            placeholder="you@example.com"
+          />
+          <label className="flex items-start gap-3 text-sm text-[rgba(255,247,237,0.85)]">
+            <input
+              type="checkbox"
+              checked={sendEmails}
+              onChange={(e) => setSendEmails(e.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-[rgba(255,214,150,0.5)] bg-[rgba(249,115,22,0.15)] text-[rgba(249,115,22,0.9)] focus:ring-[rgba(249,115,22,0.5)]"
+            />
+            <span>Send session summaries by email</span>
+          </label>
+        </div>
+        <div className="mt-6 flex items-center gap-3">
+          <button
+            onClick={() => {
+              const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, activeHandle)
+              const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, activeHandle)
+              localStorage.setItem(emailKey, email)
+              localStorage.setItem(enabledKey, sendEmails ? 'true' : 'false')
+              setSaved(true)
+            }}
+            className="rounded-full border border-[rgba(249,115,22,0.45)] bg-gradient-to-r from-[#f59e0b] via-[#f97316] to-[#d946ef] px-6 py-2 text-sm font-semibold text-white shadow-[0_15px_45px_rgba(249,115,22,0.35)] transition hover:from-[#f97316] hover:via-[#ec4899] hover:to-[#8b5cf6]"
+          >
+            Save preferences
+          </button>
+          {saved && <span className="text-xs text-[rgba(255,247,237,0.7)]">Saved.</span>}
+        </div>
+      </section>
     </main>
   )
 }

--- a/app/u/[handle]/page.tsx
+++ b/app/u/[handle]/page.tsx
@@ -1,0 +1,6 @@
+import { Home } from '../../page'
+
+export default function UserHomePage({ params }: { params: { handle: string } }) {
+  const handle = params.handle || ''
+  return <Home key={`user:${handle.toLowerCase()}`} userHandle={handle} />
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -2,12 +2,14 @@ import { putBlobFromBuffer, listBlobs, deleteBlobsByPrefix, deleteBlob } from '.
 import { sendSummaryEmail } from './email'
 import { flagFox } from './foxes'
 import { generateSessionTitle, SummarizableTurn } from './session-title'
+import { normalizeHandle } from './user-scope'
 
 export type Session = {
   id: string
   created_at: string
   title?: string
   email_to: string
+  user_handle?: string | null
   status: 'in_progress' | 'completed' | 'emailed' | 'error'
   duration_ms: number
   total_turns: number
@@ -288,13 +290,21 @@ export async function dbHealth() {
   return { ok: true, mode: 'memory' }
 }
 
-export async function createSession({ email_to }: { email_to: string }): Promise<Session> {
+export async function createSession({
+  email_to,
+  user_handle,
+}: {
+  email_to: string
+  user_handle?: string | null
+}): Promise<Session> {
   await ensureSessionMemoryHydrated().catch(() => undefined)
   await getMemoryPrimer().catch(() => undefined)
+  const normalizedHandle = normalizeHandle(user_handle ?? undefined) ?? null
   const s: RememberedSession = {
     id: uid(),
     created_at: new Date().toISOString(),
     email_to,
+    user_handle: normalizedHandle,
     status: 'in_progress',
     duration_ms: 0,
     total_turns: 0,
@@ -393,7 +403,6 @@ export async function finalizeSession(
     summaryCandidates.push({ role: 'user', text: turn.text })
     if (turn.assistant) {
       transcriptLines.push(`Assistant: ${turn.assistant.text}`)
-      summaryCandidates.push({ role: 'assistant', text: turn.assistant.text })
     }
   }
 
@@ -444,6 +453,8 @@ export async function finalizeSession(
     sessionId: s.id,
     created_at: s.created_at,
     email: s.email_to,
+    user_handle: s.user_handle ?? null,
+    userHandle: s.user_handle ?? null,
     title: s.title,
     totals: { turns: turns.length, durationMs: s.duration_ms },
     turns: turns.map((t) => ({ id: t.id, role: t.role, text: t.text, audio: t.audio || null })),
@@ -630,10 +641,47 @@ export async function clearAllSessions(): Promise<{ ok: boolean }> {
   return { ok: true }
 }
 
-export async function listSessions(): Promise<Session[]> {
+export async function deleteSessionsByHandle(
+  handle?: string | null,
+): Promise<{ ok: boolean; deleted: number }> {
   await ensureSessionMemoryHydrated().catch(() => undefined)
+  const normalizedHandle = normalizeHandle(handle ?? undefined)
+  const idsToDelete: string[] = []
+  for (const session of mem.sessions.values()) {
+    const sessionHandle = normalizeHandle(session.user_handle ?? undefined)
+    if (normalizedHandle) {
+      if (sessionHandle === normalizedHandle) {
+        idsToDelete.push(session.id)
+      }
+    } else if (!sessionHandle) {
+      idsToDelete.push(session.id)
+    }
+  }
+
+  let deleted = 0
+  for (const id of idsToDelete) {
+    try {
+      const result = await deleteSession(id)
+      if (result.deleted) deleted += 1
+    } catch {
+      // ignore errors so one bad session doesn't block others
+    }
+  }
+
+  return { ok: true, deleted }
+}
+
+export async function listSessions(handle?: string | null): Promise<Session[]> {
+  await ensureSessionMemoryHydrated().catch(() => undefined)
+  const normalizedHandle = normalizeHandle(handle ?? undefined)
   const seen = new Map<string, RememberedSession>()
   for (const session of mem.sessions.values()) {
+    const sessionHandle = normalizeHandle(session.user_handle ?? undefined)
+    if (normalizedHandle) {
+      if (sessionHandle !== normalizedHandle) continue
+    } else if (sessionHandle) {
+      continue
+    }
     seen.set(session.id, { ...session, turns: session.turns ? [...session.turns] : [] })
   }
   return Array.from(seen.values()).sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
@@ -796,6 +844,14 @@ export function buildSessionFromManifest(
     created_at: createdAt,
     title: typeof data.title === 'string' ? data.title : undefined,
     email_to: typeof data.email === 'string' ? data.email : process.env.DEFAULT_NOTIFY_EMAIL || '',
+    user_handle:
+      normalizeHandle(
+        typeof data.user_handle === 'string'
+          ? data.user_handle
+          : typeof data.userHandle === 'string'
+          ? data.userHandle
+          : undefined,
+      ) ?? null,
     status: 'completed',
     duration_ms: durationMs,
     total_turns: totalTurns,

--- a/lib/session-title.ts
+++ b/lib/session-title.ts
@@ -3,6 +3,8 @@ export type SummarizableTurn = {
   text?: string | null
 }
 
+type SummarizableTextTurn = SummarizableTurn & { text: string }
+
 function splitIntoSentences(text: string): string[] {
   const cleaned = text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()
   if (!cleaned) return []
@@ -56,31 +58,43 @@ export function generateSessionTitle(
     return fallback
   }
 
-  const candidates: { sentence: string; score: number; role: SummarizableTurn['role'] }[] = []
+  const normalizeTurns = (source: SummarizableTurn[] | undefined | null): SummarizableTextTurn[] =>
+    (source || []).filter((turn): turn is SummarizableTextTurn => {
+      return Boolean(turn && typeof turn.text === 'string' && turn.text.trim())
+    })
 
-  for (const turn of turns) {
-    if (!turn || typeof turn.text !== 'string') continue
-    const trimmed = turn.text.replace(/\s+/g, ' ').trim()
-    if (!trimmed) continue
-    const sentences = splitIntoSentences(trimmed)
-    for (const sentence of sentences) {
-      const scored = scoreSentence(sentence, turn.role)
-      if (scored <= 0) continue
-      candidates.push({ sentence, score: scored, role: turn.role })
+  const buildCandidates = (source: SummarizableTextTurn[]) => {
+    const candidates: { sentence: string; score: number; role: SummarizableTurn['role'] }[] = []
+    for (const turn of source) {
+      const trimmed = turn.text.replace(/\s+/g, ' ').trim()
+      if (!trimmed) continue
+      const sentences = splitIntoSentences(trimmed)
+      for (const sentence of sentences) {
+        const scored = scoreSentence(sentence, turn.role)
+        if (scored <= 0) continue
+        candidates.push({ sentence, score: scored, role: turn.role })
+      }
     }
+    return candidates
   }
 
-  if (!candidates.length) {
-    return fallback
+  const pickCandidate = (candidates: { sentence: string; score: number; role: SummarizableTurn['role'] }[]) => {
+    if (!candidates.length) return undefined
+    candidates.sort((a, b) => b.score - a.score)
+    const preferred = candidates.find((entry) => entry.role === 'user' && entry.sentence.split(' ').length >= 3)
+    const chosen = preferred || candidates[0]
+    const finalized = finalizeSentence(chosen.sentence)
+    return finalized || undefined
   }
 
-  candidates.sort((a, b) => b.score - a.score)
+  const normalized = normalizeTurns(turns)
+  const userTurns = normalized.filter((turn) => turn.role === 'user')
 
-  const preferred = candidates.find((entry) => entry.role === 'user' && entry.sentence.split(' ').length >= 3)
-  const chosen = preferred || candidates[0]
-  const finalized = finalizeSentence(chosen.sentence)
-  if (finalized) {
-    return finalized
-  }
+  const userTitle = pickCandidate(buildCandidates(userTurns))
+  if (userTitle) return userTitle
+
+  const fallbackTitle = pickCandidate(buildCandidates(normalized))
+  if (fallbackTitle) return fallbackTitle
+
   return fallback
 }

--- a/lib/user-scope.ts
+++ b/lib/user-scope.ts
@@ -1,0 +1,25 @@
+export const SESSION_STORAGE_BASE_KEY = 'sessionId'
+export const EMAIL_STORAGE_BASE_KEY = 'defaultEmail'
+export const EMAIL_ENABLED_STORAGE_BASE_KEY = 'sendSummaryEmails'
+export const DEMO_HISTORY_BASE_KEY = 'demoHistory'
+export const ACTIVE_USER_HANDLE_STORAGE_KEY = 'activeUserHandle'
+export const DEFAULT_NOTIFY_EMAIL = 'a@sarva.co'
+
+const DEFAULT_SCOPE_KEY = '__default__'
+
+export function normalizeHandle(handle?: string | null): string | undefined {
+  if (!handle) return undefined
+  if (typeof handle !== 'string') return undefined
+  const trimmed = handle.trim()
+  if (!trimmed.length) return undefined
+  return trimmed.toLowerCase()
+}
+
+export function deriveUserScopeKey(handle?: string | null): string {
+  return normalizeHandle(handle) ?? DEFAULT_SCOPE_KEY
+}
+
+export function scopedStorageKey(base: string, handle?: string | null): string {
+  const normalized = normalizeHandle(handle)
+  return normalized ? `${base}:${normalized}` : base
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,7 +44,12 @@ export default function App(){
       const { reply, transcript, end_intent } = askRes
 
       const endRegex = /(i[' ]?m done|stop for now|that’s all|i’m finished|we’re done|let’s stop)/i
-      const shouldEnd = end_intent === true || (transcript && endRegex.test(transcript))
+      const providerSuggestedStop = end_intent === true
+      const userRequestedStop = Boolean(transcript && endRegex.test(transcript))
+      if (providerSuggestedStop && !userRequestedStop) {
+        console.debug('Provider end intent ignored — awaiting user request to finish.')
+      }
+      const shouldEnd = userRequestedStop
 
       const save = await fetch('/api/save-turn', {
         method:'POST', headers:{'Content-Type':'application/json'},

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -199,4 +199,27 @@ describe('session deletion helpers', () => {
     const sessions = await data.listSessions()
     expect(sessions).toEqual([])
   })
+
+  it('scopes listing and deletion by user handle', async () => {
+    const data = await import('../lib/data')
+    sendEmailMock.mockResolvedValue({ skipped: true })
+
+    const defaultSession = await data.createSession({ email_to: '' })
+    const handledSession = await data.createSession({ email_to: '', user_handle: 'Amol' })
+
+    const defaultSessions = await data.listSessions()
+    expect(defaultSessions.map((s) => s.id)).toContain(defaultSession.id)
+    expect(defaultSessions.some((s) => s.id === handledSession.id)).toBe(false)
+
+    const scopedSessions = await data.listSessions('amol')
+    expect(scopedSessions.map((s) => s.id)).toEqual([handledSession.id])
+
+    await data.deleteSessionsByHandle('amol')
+
+    const afterDeletionScoped = await data.listSessions('amol')
+    expect(afterDeletionScoped).toEqual([])
+
+    const remainingDefault = await data.listSessions()
+    expect(remainingDefault.map((s) => s.id)).toContain(defaultSession.id)
+  })
 })


### PR DESCRIPTION
## Summary
- rewrite the history API handler to properly scope by handle while keeping manifest/audio metadata intact
- add a helper for extracting summarizable user turns so title generation remains stable after the merge

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfad9f7550832aa5779a5b10394f32