### PR TITLE
Restore Indian-inspired styling across Next pages

### DIFF
--- a/app/diagnostics/page.tsx
+++ b/app/diagnostics/page.tsx
@@ -149,62 +149,54 @@ export default function DiagnosticsPage() {
 
   return (
     <main>
-      <h2 className="text-lg font-semibold mb-3">Diagnostics</h2>
-      <button
-        onClick={runDiagnostics}
-        disabled={isRunning}
-        className="bg-white/10 px-4 py-2 rounded-2xl disabled:opacity-50"
-      >
-        {isRunning ? 'Running…' : 'Run full diagnostics'}
-      </button>
+      <div className="panel-card diagnostics-panel">
+        <h2 className="page-heading">Diagnostics</h2>
+        <button onClick={runDiagnostics} disabled={isRunning} className="btn-secondary btn-large">
+          {isRunning ? 'Running…' : 'Run full diagnostics'}
+        </button>
 
-      <div className="mt-4 space-y-3">
-        {TEST_ORDER.map(key => {
-          const result = results[key]
-          return (
-            <div key={key} className="bg-white/5 rounded-xl px-4 py-3">
-              <div className="flex items-center gap-2">
-                <span className="text-xl leading-none">{statusIcon[result.status]}</span>
-                <span className="font-medium">{TEST_CONFIG[key].label}</span>
+        <div className="diagnostics-tests">
+          {TEST_ORDER.map((key) => {
+            const result = results[key]
+            return (
+              <div key={key} className="diagnostic-card">
+                <div className="diagnostic-card-head">
+                  <span className="diagnostic-icon" aria-hidden="true">
+                    {statusIcon[result.status]}
+                  </span>
+                  <span className="diagnostic-label">{TEST_CONFIG[key].label}</span>
+                </div>
+                {result.message && <div className="diagnostic-message">{result.message}</div>}
               </div>
-              {result.message && (
-                <div className="mt-1 text-sm opacity-80 whitespace-pre-wrap">{result.message}</div>
-              )}
-            </div>
-          )
-        })}
-      </div>
+            )
+          })}
+        </div>
 
-      <textarea
-        value={log}
-        readOnly
-        className="mt-4 w-full h-96 bg-black/30 p-2 rounded"
-      />
+        <textarea value={log} readOnly rows={12} className="diagnostics-log" />
 
-      <div className="mt-4">
-        <h3 className="font-semibold mb-2">Tracked foxes</h3>
-        {foxes.length === 0 ? (
-          <p className="text-sm opacity-70">No foxes have been triggered yet.</p>
-        ) : (
-          <ul className="space-y-2 text-sm">
-            {foxes.map(fox => (
-              <li key={fox.id} className="bg-white/5 rounded-xl px-3 py-2">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-medium">Theory {fox.theory} – {fox.message}</span>
-                  <span className="text-xs uppercase tracking-wide opacity-70">{fox.level}</span>
-                </div>
-                <div className="text-xs opacity-70 mt-1">
-                  Count: {fox.count} · Last: {new Date(fox.lastTriggeredAt).toLocaleString()}
-                </div>
-                {fox.details && (
-                  <pre className="mt-2 text-xs bg-black/40 p-2 rounded whitespace-pre-wrap">
-                    {JSON.stringify(fox.details, null, 2)}
-                  </pre>
-                )}
-              </li>
-            ))}
-          </ul>
-        )}
+        <div className="diagnostics-foxes">
+          <h3>Tracked foxes</h3>
+          {foxes.length === 0 ? (
+            <p className="status-note">No foxes have been triggered yet.</p>
+          ) : (
+            <ul className="diagnostics-fox-list">
+              {foxes.map((fox) => (
+                <li key={fox.id} className="diagnostic-card">
+                  <div className="fox-head">
+                    <span className="fox-title">Theory {fox.theory} – {fox.message}</span>
+                    <span className="fox-level">{fox.level}</span>
+                  </div>
+                  <div className="fox-meta">
+                    Count: {fox.count} · Last: {new Date(fox.lastTriggeredAt).toLocaleString()}
+                  </div>
+                  {fox.details && (
+                    <pre className="fox-details">{JSON.stringify(fox.details, null, 2)}</pre>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
     </main>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,43 +1,841 @@
+@import url('https://fonts.googleapis.com/css2?family=Mukta:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-:root { --bg: #0b0c10; --fg: #e5e7eb; }
-html, body { height: 100%; }
-body { background: var(--bg); color: var(--fg); }
-button { @apply rounded-2xl px-4 py-2 font-medium; }
-textarea { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
-a { text-underline-offset: 2px; }
 
-@keyframes softPulse {
-  from {
-    transform: scale(0.96);
-    opacity: 0.8;
-  }
-  to {
-    transform: scale(1.04);
-    opacity: 1;
-  }
+:root {
+  color-scheme: light;
+  --bg:#fff9f0;
+  --bg-accent:#fff2da;
+  --bg-ribbon:#fef0d6;
+  --card:rgba(255,255,255,.92);
+  --ink:#2d1606;
+  --muted:#734a2b;
+  --accent:#f97316;
+  --accent-quiet:#ffe0c2;
+  --accent-deep:#0f7c4b;
+  --border:#f3cba5;
+  --ring-saffron:#ff9248;
+  --ring-green:#1b8d55;
+  --shadow:rgba(83,39,9,.18);
 }
 
-.animate-soft-pulse {
-  animation: softPulse 3.5s ease-in-out infinite alternate;
+html,
+body {
+  height: 100%;
 }
 
-@keyframes slowRipple {
+body {
+  margin: 0;
+  min-height: 100%;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255, 204, 128, 0.35), transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(125, 211, 161, 0.3), transparent 58%),
+    var(--bg);
+  color: var(--ink);
+  font-family: "Mukta", Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial;
+  position: relative;
+  line-height: 1.6;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(120deg, rgba(255, 153, 51, 0.12) 0%, rgba(255, 255, 255, 0) 45%, rgba(19, 136, 8, 0.12) 100%);
+  z-index: -1;
+}
+
+a {
+  color: var(--accent-deep);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition: color 0.18s ease;
+}
+
+a:hover {
+  color: #0a5f38;
+}
+
+.link {
+  color: var(--accent-deep);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.link:hover {
+  color: #0a5f38;
+}
+
+.site-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 30px 20px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  background: linear-gradient(135deg, rgba(255, 186, 102, 0.92), rgba(255, 247, 237, 0.9) 38%, rgba(255, 247, 237, 0.88) 62%, rgba(121, 205, 159, 0.9));
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  box-shadow: 0 18px 46px rgba(77, 42, 5, 0.16);
+  backdrop-filter: blur(8px);
+}
+
+.site-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  font-size: 22px;
+  color: var(--ink);
+}
+
+.site-title::after {
+  content: "ॐ";
+  font-size: 18px;
+  color: var(--accent-deep);
+  filter: drop-shadow(0 1px 2px rgba(15, 124, 75, 0.3));
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.site-nav a {
+  text-decoration: none;
+  color: var(--muted);
+  padding: 8px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(243, 203, 165, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 4px 12px rgba(83, 39, 9, 0.12);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.site-nav a:hover {
+  background: rgba(255, 247, 237, 0.96);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75), 0 6px 16px rgba(83, 39, 9, 0.16);
+}
+
+.site-footer {
+  margin-top: 32px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.panel-card {
+  position: relative;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 26px;
+  padding: 26px;
+  box-shadow: 0 26px 60px var(--shadow);
+  backdrop-filter: blur(8px);
+  overflow: hidden;
+}
+
+.panel-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 153, 51, 0.18), rgba(255, 255, 255, 0) 40%, rgba(19, 136, 8, 0.12));
+  pointer-events: none;
+  opacity: 0.8;
+}
+
+.panel-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.home-main {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  align-items: center;
+}
+
+.hero-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  text-align: center;
+}
+
+.account-chip {
+  font-size: 13px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(243, 203, 165, 0.6);
+  border-radius: 14px;
+  padding: 6px 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+button {
+  border: none;
+  background: linear-gradient(135deg, var(--accent) 0%, #ffb454 55%, #ffa94d 100%);
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 18px;
+  font-weight: 700;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  box-shadow: 0 12px 28px rgba(249, 115, 22, 0.24);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(249, 115, 22, 0.32);
+}
+
+button:active {
+  transform: translateY(0);
+  filter: brightness(0.97);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+button.btn-secondary {
+  background: linear-gradient(135deg, rgba(15, 124, 75, 0.95), rgba(15, 124, 75, 0.78));
+  box-shadow: 0 12px 30px rgba(15, 124, 75, 0.26);
+  border-radius: 999px;
+}
+
+button.btn-secondary:hover {
+  box-shadow: 0 16px 38px rgba(15, 124, 75, 0.32);
+}
+
+button.btn-outline {
+  background: rgba(255, 255, 255, 0.36);
+  color: var(--muted);
+  border: 1px solid rgba(243, 203, 165, 0.8);
+  box-shadow: none;
+  border-radius: 999px;
+  padding: 9px 18px;
+}
+
+button.btn-outline:hover {
+  background: rgba(255, 247, 237, 0.9);
+  color: var(--ink);
+  box-shadow: none;
+}
+
+button.btn-outline:disabled {
+  color: rgba(115, 74, 43, 0.6);
+  background: rgba(255, 255, 255, 0.4);
+}
+
+button.link-button {
+  background: none;
+  color: var(--accent-deep);
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+button.link-button:hover {
+  transform: none;
+  filter: none;
+  text-decoration: underline;
+}
+
+button.link-button:disabled {
+  opacity: 0.5;
+}
+
+.link-danger {
+  color: #b91c1c;
+}
+
+.link-danger:hover {
+  color: #7f1d1d;
+}
+
+button.hero-button {
+  --hero-accent: var(--accent);
+  --hero-gradient: linear-gradient(135deg, rgba(255, 153, 51, 0.22), rgba(255, 255, 255, 0) 48%, rgba(19, 136, 8, 0.16));
+  --hero-glow: rgba(249, 115, 22, 0.32);
+  position: relative;
+  width: min(420px, 78vw);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.92), rgba(255, 234, 208, 0.9));
+  border: 10px solid rgba(255, 214, 170, 0.9);
+  box-shadow: 0 20px 48px rgba(83, 39, 9, 0.2);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--ink);
+}
+
+button.hero-button::before {
+  content: "";
+  position: absolute;
+  inset: -14px;
+  border-radius: 999px;
+  background: conic-gradient(from 120deg, var(--ring-saffron), rgba(255, 153, 51, 0.32), var(--ring-green), rgba(19, 136, 8, 0.28), var(--ring-saffron));
+  opacity: 0.6;
+  filter: blur(0.4px);
+  z-index: 0;
+}
+
+button.hero-button::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 999px;
+  border: 4px dashed rgba(15, 124, 75, 0.16);
+  pointer-events: none;
+}
+
+button.hero-button .hero-button__pulse {
+  position: absolute;
+  inset: 14%;
+  border-radius: 999px;
+  border: 4px solid rgba(249, 115, 22, 0.22);
+  opacity: 0;
+}
+
+button.hero-button.is-recording .hero-button__pulse {
+  animation: heroPulse 2.2s infinite;
+  opacity: 1;
+  border-color: rgba(249, 115, 22, 0.32);
+}
+
+button.hero-button .hero-button__gradient {
+  position: absolute;
+  inset: 0;
+  background: var(--hero-gradient);
+  opacity: 0.75;
+  mix-blend-mode: multiply;
+}
+
+button.hero-button .hero-button__dot {
+  position: absolute;
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--hero-accent), #ffbf75);
+  box-shadow: 0 12px 26px var(--hero-glow);
+  z-index: 0;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+  filter: saturate(0.95);
+}
+
+button.hero-button .hero-button__content {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px;
+  text-align: center;
+}
+
+button.hero-button .hero-button__icon {
+  font-size: clamp(40px, 8vw, 64px);
+}
+
+button.hero-button .hero-button__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+  letter-spacing: 0.36em;
+  font-size: 11px;
+  color: var(--accent-deep);
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 999px;
+  padding: 6px 18px;
+  box-shadow: 0 8px 20px rgba(15, 124, 75, 0.16);
+}
+
+button.hero-button .hero-button__title {
+  font-size: clamp(26px, 5vw, 34px);
+  font-weight: 600;
+  color: var(--ink);
+}
+
+button.hero-button .hero-button__description {
+  font-size: clamp(14px, 3vw, 16px);
+  color: var(--muted);
+  line-height: 1.55;
+  max-width: 280px;
+}
+
+button.hero-button:hover {
+  box-shadow: 0 24px 60px rgba(83, 39, 9, 0.22);
+}
+
+button.hero-button:focus-visible {
+  outline: 3px solid rgba(255, 153, 51, 0.32);
+  outline-offset: 6px;
+}
+
+button.hero-button.is-finishing {
+  --hero-accent: #f97316;
+  --hero-gradient: linear-gradient(135deg, rgba(255, 186, 102, 0.3), rgba(255, 247, 237, 0.86));
+  --hero-glow: rgba(249, 115, 22, 0.36);
+}
+
+button.hero-button.is-stopping {
+  --hero-accent: #f87171;
+  --hero-gradient: linear-gradient(135deg, rgba(248, 113, 113, 0.24), rgba(244, 114, 182, 0.2));
+  --hero-glow: rgba(248, 113, 113, 0.3);
+}
+
+.status-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  text-align: center;
+}
+
+.status-text {
+  font-size: 16px;
+  color: var(--muted);
+  max-width: 460px;
+}
+
+button.btn-large {
+  padding: 12px 28px;
+  border-radius: 999px;
+  font-size: 16px;
+}
+
+.diagnostics-card textarea,
+textarea.diagnostics-log {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(243, 203, 165, 0.7);
+  border-radius: 18px;
+  padding: 14px;
+  color: var(--muted);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  resize: vertical;
+}
+
+.diagnostics-card {
+  width: 100%;
+  max-width: 720px;
+}
+
+.diagnostics-card .diagnostics-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 11px;
+  color: rgba(115, 74, 43, 0.72);
+}
+
+.diagnostics-card .diagnostics-link {
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-deep);
+}
+
+.diagnostics-card .diagnostics-link:hover {
+  color: #0a5f38;
+}
+
+.diagnostics-panel {
+  width: 100%;
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.diagnostics-tests {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.diagnostic-card {
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(243, 203, 165, 0.7);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 18px 36px rgba(83, 39, 9, 0.12);
+}
+
+.diagnostic-card-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.diagnostic-icon {
+  font-size: 24px;
+}
+
+.diagnostic-label {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.diagnostic-message {
+  margin-top: 8px;
+  font-size: 14px;
+  color: var(--muted);
+  white-space: pre-wrap;
+}
+
+.diagnostics-foxes {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.diagnostics-foxes h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--ink);
+}
+
+.diagnostics-fox-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fox-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.fox-title {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.fox-level {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(115, 74, 43, 0.72);
+}
+
+.fox-meta {
+  font-size: 12px;
+  color: rgba(115, 74, 43, 0.75);
+  margin-top: 6px;
+}
+
+.fox-details {
+  margin-top: 10px;
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(243, 203, 165, 0.6);
+  border-radius: 14px;
+  padding: 12px;
+  white-space: pre-wrap;
+  color: var(--muted);
+}
+
+.diagnostics-card textarea:focus,
+textarea.diagnostics-log:focus {
+  outline: 2px solid rgba(255, 153, 51, 0.25);
+  box-shadow: 0 0 0 3px rgba(255, 153, 51, 0.16);
+}
+
+label {
+  color: var(--muted);
+}
+
+input[type="text"],
+input[type="email"],
+textarea,
+select {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(243, 203, 165, 0.8);
+  border-radius: 16px;
+  padding: 11px 14px;
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 14px;
+  box-shadow: 0 10px 22px rgba(83, 39, 9, 0.08);
+}
+
+input[type="checkbox"] {
+  accent-color: var(--accent-deep);
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.history-item {
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(243, 203, 165, 0.7);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 18px 36px rgba(83, 39, 9, 0.12);
+}
+
+.history-item-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.history-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.history-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.history-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.history-footer {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.history-item h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--ink);
+}
+
+.history-meta {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 6px;
+}
+
+.history-empty {
+  background: rgba(255, 247, 237, 0.86);
+  border: 1px dashed rgba(243, 203, 165, 0.8);
+  border-radius: 18px;
+  padding: 20px;
+  color: var(--muted);
+  font-size: 14px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.session-turn {
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(243, 203, 165, 0.7);
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: 0 14px 32px rgba(83, 39, 9, 0.12);
+}
+
+.session-turn + .session-turn {
+  margin-top: 10px;
+}
+
+.session-turn-role {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(115, 74, 43, 0.75);
+}
+
+.session-card {
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.session-turns {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.session-turn-text {
+  margin-top: 6px;
+  color: var(--ink);
+  white-space: pre-wrap;
+}
+
+.session-turn-audio {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.session-links {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 14px;
+}
+
+.page-heading {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 12px;
+}
+
+.page-subtext {
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.highlight {
+  font-weight: 600;
+  color: var(--accent-deep);
+}
+
+.page-subtext .highlight {
+  font-weight: 600;
+  color: var(--accent-deep);
+}
+
+.panel-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.tag-label {
+  font-size: 11px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: rgba(115, 74, 43, 0.72);
+}
+
+.settings-card {
+  max-width: 620px;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 18px;
+  color: var(--muted);
+}
+
+.settings-field input {
+  max-width: 360px;
+}
+
+.settings-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.settings-actions {
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.status-note {
+  font-size: 12px;
+  color: rgba(115, 74, 43, 0.7);
+}
+
+@keyframes heroPulse {
   0% {
-    transform: scale(1);
-    opacity: 0.35;
+    box-shadow: 0 0 0 0 rgba(249, 115, 22, 0.32);
   }
   70% {
-    transform: scale(1.24);
-    opacity: 0;
+    box-shadow: 0 0 0 38px rgba(249, 115, 22, 0);
   }
   100% {
-    transform: scale(1.34);
-    opacity: 0;
+    box-shadow: 0 0 0 0 rgba(249, 115, 22, 0);
   }
 }
 
-.animate-slow-ripple {
-  animation: slowRipple 4.5s ease-out infinite;
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .site-nav {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .panel-card {
+    padding: 22px;
+  }
+
+  button.hero-button {
+    width: min(360px, 84vw);
+  }
+
+  .site-shell {
+    padding: 24px 16px 48px;
+  }
 }

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -136,54 +136,56 @@ export default function HistoryPage() {
 
   return (
     <main>
-      <h2 className="text-lg font-semibold mb-4">Sessions</h2>
-      {activeHandle && (
-        <p className="-mt-2 mb-4 text-xs text-white/60">
-          Showing sessions saved for <span className="font-semibold text-white">@{activeHandle}</span>
-        </p>
-      )}
-      {rows.length === 0 ? (
-        <div className="rounded border border-dashed border-white/10 bg-white/5 p-4 text-sm text-white/70">
-          <p className="font-medium text-white">No interviews yet.</p>
-          <p className="mt-1">Run a mock session from the home page or execute diagnostics to record a sample conversation. Your completed interviews will appear here once they are saved.</p>
-        </div>
-      ) : (
-        <ul className="space-y-3">
-          {rows.map(s => (
-            <li key={s.id} className="bg-white/5 rounded p-3">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <div className="font-medium">
-                    {s.title || `Session from ${new Date(s.created_at).toLocaleString()}`}
-                  </div>
-                  <div className="text-xs opacity-70">{new Date(s.created_at).toLocaleString()}</div>
-                  <div className="text-xs opacity-70">Turns: {s.total_turns} • Status: {s.status}</div>
+      <div className="panel-card">
+        <h2 className="page-heading">Sessions</h2>
+        {activeHandle && (
+          <p className="page-subtext">
+            Showing sessions saved for <span className="highlight">@{activeHandle}</span>
+          </p>
+        )}
+        {rows.length === 0 ? (
+          <div className="history-empty">
+            <p className="font-medium">No interviews yet.</p>
+            <p className="mt-1">
+              Run a mock session from the home page or execute diagnostics to record a sample conversation. Your completed
+              interviews will appear here once they are saved.
+            </p>
+          </div>
+        ) : (
+          <ul className="history-list">
+            {rows.map((s) => (
+              <li key={s.id} className="history-item">
+                <div className="history-item-header">
+                  <h3>{s.title || `Session from ${new Date(s.created_at).toLocaleString()}`}</h3>
+                  <div className="history-meta">{new Date(s.created_at).toLocaleString()}</div>
+                  <div className="history-meta">Turns: {s.total_turns} • Status: {s.status}</div>
                 </div>
-                <div className="flex flex-col gap-2 text-sm max-w-xl items-end">
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(s.id)}
-                    disabled={deletingId === s.id || clearingAll}
-                    className="text-xs text-red-200/80 hover:text-red-100 disabled:opacity-50"
-                    aria-label="Delete session"
-                  >
-                    {deletingId === s.id ? 'Deleting…' : '🗑 Remove'}
-                  </button>
-                  {(s.sessionAudioUrl || s.artifacts?.session_audio) && (
-                    <audio
-                      controls
-                      src={(s.sessionAudioUrl || s.artifacts?.session_audio) ?? undefined}
-                      className="w-full"
-                    />
-                  )}
-                  <div className="flex flex-wrap gap-2">
-                    <a className="underline" href={`/session/${s.id}`}>
+                <div className="history-item-body">
+                  <div className="history-actions">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(s.id)}
+                      disabled={deletingId === s.id || clearingAll}
+                      className="link-button link-danger"
+                      aria-label="Delete session"
+                    >
+                      {deletingId === s.id ? 'Deleting…' : '🗑 Remove'}
+                    </button>
+                    {(s.sessionAudioUrl || s.artifacts?.session_audio) && (
+                      <audio
+                        controls
+                        src={(s.sessionAudioUrl || s.artifacts?.session_audio) ?? undefined}
+                        className="w-full"
+                      />
+                    )}
+                  </div>
+                  <div className="history-links">
+                    <a className="link" href={`/session/${s.id}`}>
                       Open
                     </a>
-
                     {(s.manifestUrl || s.artifacts?.session_manifest) && (
                       <a
-                        className="underline"
+                        className="link"
                         href={(s.manifestUrl || s.artifacts?.session_manifest) ?? undefined}
                         target="_blank"
                         rel="noreferrer"
@@ -192,23 +194,23 @@ export default function HistoryPage() {
                       </a>
                     )}
                     {s.firstAudioUrl && (
-                      <a className="underline" href={s.firstAudioUrl} target="_blank" rel="noreferrer">
+                      <a className="link" href={s.firstAudioUrl} target="_blank" rel="noreferrer">
                         First turn audio
                       </a>
                     )}
                     {s.artifacts?.transcript_txt && (
-                      <a className="underline" href={s.artifacts.transcript_txt} target="_blank" rel="noreferrer">
+                      <a className="link" href={s.artifacts.transcript_txt} target="_blank" rel="noreferrer">
                         Transcript (txt)
                       </a>
                     )}
                     {s.artifacts?.transcript_json && (
-                      <a className="underline" href={s.artifacts.transcript_json} target="_blank" rel="noreferrer">
+                      <a className="link" href={s.artifacts.transcript_json} target="_blank" rel="noreferrer">
                         Transcript (json)
                       </a>
                     )}
                     {(s.sessionAudioUrl || s.artifacts?.session_audio) && (
                       <a
-                        className="underline"
+                        className="link"
                         href={(s.sessionAudioUrl || s.artifacts?.session_audio) ?? undefined}
                         target="_blank"
                         rel="noreferrer"
@@ -217,25 +219,24 @@ export default function HistoryPage() {
                       </a>
                     )}
                   </div>
-
                 </div>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-      {rows.length > 0 && (
-        <div className="mt-6 flex justify-end">
-          <button
-            type="button"
-            onClick={handleClearAll}
-            disabled={clearingAll || !!deletingId}
-            className="rounded border border-white/20 px-3 py-1 text-sm text-white/80 hover:border-white/40 hover:text-white disabled:opacity-50"
-          >
-            {clearingAll ? 'Clearing…' : 'Clear all history'}
-          </button>
-        </div>
-      )}
+              </li>
+            ))}
+          </ul>
+        )}
+        {rows.length > 0 && (
+          <div className="history-footer">
+            <button
+              type="button"
+              onClick={handleClearAll}
+              disabled={clearingAll || !!deletingId}
+              className="btn-outline"
+            >
+              {clearingAll ? 'Clearing…' : 'Clear all history'}
+            </button>
+          </div>
+        )}
+      </div>
     </main>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,21 +30,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="en">
-      <body className="min-h-screen">
-        <div className="max-w-3xl mx-auto px-4 py-6">
-          <header className="flex items-center justify-between mb-6">
-            <h1 className="text-xl font-semibold">Dad&apos;s Interview Bot</h1>
-            <nav className="space-x-4 text-sm opacity-90">
-              <a href="/" className="underline">Home</a>
-              <a href="/history" className="underline">History</a>
-              <a href="/settings" className="underline">Settings</a>
-              <a href="/diagnostics" className="underline">Diagnostics</a>
+      <body>
+        <div className="site-shell">
+          <header className="site-header">
+            <h1 className="site-title">Dad&apos;s Interview Bot</h1>
+            <nav className="site-nav">
+              <a href="/">Home</a>
+              <a href="/history">History</a>
+              <a href="/settings">Settings</a>
+              <a href="/diagnostics">Diagnostics</a>
             </nav>
           </header>
-          {children}
-          <footer className="mt-10 text-xs opacity-70">
+          <div className="panel-section">{children}</div>
+          <footer className="site-footer">
             {commitUrl ? (
-              <a href={commitUrl} className="underline">
+              <a href={commitUrl}>
                 {shortSha} — {commitMessage}
               </a>
             ) : (

--- a/app/session/[id]/page.tsx
+++ b/app/session/[id]/page.tsx
@@ -6,47 +6,57 @@ export default async function SessionPage({ params }: { params: { id: string } }
   if (!s) return <main>Not found.</main>
   return (
     <main>
-      <h2 className="text-lg font-semibold mb-2">{s.title || 'Session'}</h2>
-      <div className="text-xs opacity-70 mb-2">{new Date(s.created_at).toLocaleString()}</div>
-      <div className="text-xs opacity-70 mb-4">
-        Total entries: {s.total_turns}
-        {Number.isFinite(s.duration_ms) && s.duration_ms > 0 && (
-          <span> • Duration: {Math.round(s.duration_ms / 1000)}s</span>
-        )}
-      </div>
-      {s.artifacts?.session_audio && (
-        <div className="mb-4">
-          <div className="text-xs opacity-70 mb-1">Session audio</div>
-          <audio controls src={s.artifacts.session_audio} className="w-full max-w-xl" />
+      <div className="panel-card session-card">
+        <h2 className="page-heading">{s.title || 'Session'}</h2>
+        <div className="page-subtext">{new Date(s.created_at).toLocaleString()}</div>
+        <div className="page-subtext">
+          Total entries: {s.total_turns}
+          {Number.isFinite(s.duration_ms) && s.duration_ms > 0 && (
+            <span> • Duration: {Math.round(s.duration_ms / 1000)}s</span>
+          )}
         </div>
-      )}
-      <div className="space-y-2">
-        {s.turns?.map(t => (
-          <div key={t.id} className="bg-white/5 rounded p-2">
-            <div className="text-xs opacity-70">{t.role}</div>
-            <div className="whitespace-pre-wrap">{t.text}</div>
-            {t.audio_blob_url && (
-              <div className="mt-1 space-y-1">
-                <div className="text-[10px] uppercase tracking-wide opacity-60">Turn audio</div>
-                <audio controls src={t.audio_blob_url} className="w-full" />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-      <div className="mt-4 flex flex-wrap gap-3 text-sm">
-        {s.artifacts?.transcript_txt && <a className="underline" href={s.artifacts.transcript_txt}>Transcript (txt)</a>}
-        {s.artifacts?.transcript_json && <a className="underline" href={s.artifacts.transcript_json}>Transcript (json)</a>}
-        {(s.artifacts?.manifest || s.artifacts?.session_manifest) && (
-          <a className="underline" href={(s.artifacts.manifest || s.artifacts.session_manifest)!}>
-            Session manifest
-          </a>
-        )}
         {s.artifacts?.session_audio && (
-          <a className="underline" href={s.artifacts.session_audio} target="_blank" rel="noreferrer">
-            Session audio
-          </a>
+          <div>
+            <div className="tag-label">Session audio</div>
+            <audio controls src={s.artifacts.session_audio} className="w-full max-w-xl" />
+          </div>
         )}
+        <div className="session-turns">
+          {s.turns?.map((t) => (
+            <div key={t.id} className="session-turn">
+              <div className="session-turn-role">{t.role}</div>
+              <div className="session-turn-text">{t.text}</div>
+              {t.audio_blob_url && (
+                <div className="session-turn-audio">
+                  <div className="tag-label">Turn audio</div>
+                  <audio controls src={t.audio_blob_url} className="w-full" />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="session-links">
+          {s.artifacts?.transcript_txt && (
+            <a className="link" href={s.artifacts.transcript_txt}>
+              Transcript (txt)
+            </a>
+          )}
+          {s.artifacts?.transcript_json && (
+            <a className="link" href={s.artifacts.transcript_json}>
+              Transcript (json)
+            </a>
+          )}
+          {(s.artifacts?.manifest || s.artifacts?.session_manifest) && (
+            <a className="link" href={(s.artifacts.manifest || s.artifacts.session_manifest)!}>
+              Session manifest
+            </a>
+          )}
+          {s.artifacts?.session_audio && (
+            <a className="link" href={s.artifacts.session_audio} target="_blank" rel="noreferrer">
+              Session audio
+            </a>
+          )}
+        </div>
       </div>
     </main>
   )

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -43,32 +43,43 @@ export default function SettingsPage() {
 
   return (
     <main>
-      <h2 className="text-lg font-semibold mb-4">Settings</h2>
-      {activeHandle && (
-        <p className="-mt-2 mb-4 text-xs text-white/60">Active account: <span className="font-semibold text-white">@{activeHandle}</span></p>
-      )}
-      <label className="block text-sm mb-1">Default notify email</label>
-      <input value={email} onChange={e=>setEmail(e.target.value)} className="bg-white/10 rounded p-2 w-full max-w-md" />
-      <label className="flex items-center gap-2 text-sm mt-4">
-        <input
-          type="checkbox"
-          checked={sendEmails}
-          onChange={e => setSendEmails(e.target.checked)}
-        />
-        <span>Send session summaries by email</span>
-      </label>
-      <div className="mt-3">
-        <button
-          onClick={()=>{
-            const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, activeHandle)
-            const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, activeHandle)
-            localStorage.setItem(emailKey, email)
-            localStorage.setItem(enabledKey, sendEmails ? 'true' : 'false')
-            setSaved(true)
-          }}
-          className="bg-white/10 px-4 py-1 rounded"
-        >Save</button>
-        {saved && <span className="text-xs ml-3 opacity-70">Saved.</span>}
+      <div className="panel-card settings-card">
+        <h2 className="page-heading">Settings</h2>
+        {activeHandle && (
+          <p className="page-subtext">
+            Active account: <span className="highlight">@{activeHandle}</span>
+          </p>
+        )}
+        <div className="settings-field">
+          <label htmlFor="notify-email">Default notify email</label>
+          <input
+            id="notify-email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <label className="settings-checkbox">
+          <input
+            type="checkbox"
+            checked={sendEmails}
+            onChange={(e) => setSendEmails(e.target.checked)}
+          />
+          <span>Send session summaries by email</span>
+        </label>
+        <div className="settings-actions">
+          <button
+            onClick={() => {
+              const emailKey = scopedStorageKey(EMAIL_STORAGE_BASE_KEY, activeHandle)
+              const enabledKey = scopedStorageKey(EMAIL_ENABLED_STORAGE_BASE_KEY, activeHandle)
+              localStorage.setItem(emailKey, email)
+              localStorage.setItem(enabledKey, sendEmails ? 'true' : 'false')
+              setSaved(true)
+            }}
+          >
+            Save
+          </button>
+          {saved && <span className="status-note">Saved.</span>}
+        </div>
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- revive the Indian-inspired light theme in the Next.js UI with new global colors, typography, and reusable button/link styles
- restyle the home interview experience with a saffron-and-green hero control, refreshed status text, and diagnostics log card
- update history, settings, diagnostics, and session views to use the new palette, panels, and link treatments for consistency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d6463e625c832aa87944966aedeeb1