### PR TITLE
Surface provider errors in UI diagnostics

### DIFF
--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -82,6 +82,8 @@ type AskAudioResponse = {
     usedFallback: boolean
     reason?: string
     providerResponseSnippet?: string
+    providerStatus?: number | null
+    providerError?: string | null
     memory?: {
       hasPriorSessions: boolean
       hasCurrentConversation: boolean
@@ -259,7 +261,7 @@ export async function POST(req: NextRequest) {
     if (text) parts.push({ text })
     parts.push({ text: 'Respond only with JSON in the format {"reply":"...","transcript":"...","end_intent":false}.' })
 
-    const model = process.env.GOOGLE_MODEL || 'gemini-1.5-flash'
+    const model = process.env.GOOGLE_MODEL || 'gemini-1.5-flash-latest'
     const response = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GOOGLE_API_KEY}`,
       {
@@ -271,6 +273,18 @@ export async function POST(req: NextRequest) {
     const json = await response.json().catch(() => ({}))
     const txt =
       json?.candidates?.[0]?.content?.parts?.map((part: any) => part?.text || '').filter(Boolean).join('\n') || ''
+    const providerStatus = response.status
+    const providerErrorMessage =
+      typeof json?.error?.message === 'string'
+        ? json.error.message
+        : typeof json?.error === 'string'
+        ? json.error
+        : !response.ok
+        ? response.statusText || 'Provider request failed'
+        : null
+    const providerResponseSnippet = (txt && txt.trim().length
+      ? txt
+      : JSON.stringify(json?.error || json) || '').slice(0, 400)
 
     const fallback: AskAudioResponse = {
       ok: true,
@@ -278,7 +292,14 @@ export async function POST(req: NextRequest) {
       reply: fallbackReply,
       transcript: text || '',
       end_intent: detectCompletionIntent(text || '').shouldStop,
-      debug: { ...debugBase, usedFallback: true, reason: 'fallback_guard' },
+      debug: {
+        ...debugBase,
+        usedFallback: true,
+        reason: 'fallback_guard',
+        providerStatus,
+        providerError: providerErrorMessage,
+        providerResponseSnippet,
+      },
     }
 
     const parsed = parseJsonFromText(txt)
@@ -348,7 +369,9 @@ export async function POST(req: NextRequest) {
         debug: {
           ...debugBase,
           usedFallback: false,
-          providerResponseSnippet: txt.slice(0, 400),
+          providerResponseSnippet,
+          providerStatus,
+          providerError: providerErrorMessage,
         },
       })
     }
@@ -358,6 +381,11 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(fallback)
     }
     const completion = detectCompletionIntent(txt || text || '')
+    const fallbackReason = !response.ok
+      ? 'provider_error'
+      : txt.trim().length
+      ? 'unstructured_response'
+      : 'empty_response'
     return NextResponse.json({
       ...fallback,
       reply: txt || fallback.reply,
@@ -366,8 +394,10 @@ export async function POST(req: NextRequest) {
       debug: {
         ...debugBase,
         usedFallback: true,
-        reason: 'unstructured_response',
-        providerResponseSnippet: txt.slice(0, 400),
+        reason: fallbackReason,
+        providerResponseSnippet,
+        providerStatus,
+        providerError: providerErrorMessage,
       },
     })
   } catch (e) {

--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -293,7 +293,7 @@ export async function POST(req: NextRequest) {
     const providerResponseSnippet = (txt && txt.trim().length
       ? txt
       : JSON.stringify(json?.error || json) || '').slice(0, 400)
-    const fallbackReason = response.ok
+    const initialFallbackReason = response.ok
       ? txt.trim().length
         ? 'fallback_guard'
         : 'empty_response'
@@ -308,7 +308,7 @@ export async function POST(req: NextRequest) {
       debug: {
         ...debugBase,
         usedFallback: true,
-        reason: fallbackReason,
+        reason: initialFallbackReason,
         providerStatus,
         providerError: providerErrorMessage,
         providerResponseSnippet,

--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -261,7 +261,7 @@ export async function POST(req: NextRequest) {
     if (text) parts.push({ text })
     parts.push({ text: 'Respond only with JSON in the format {"reply":"...","transcript":"...","end_intent":false}.' })
 
-    const model = process.env.GOOGLE_MODEL || 'gemini-1.5-flash-latest'
+    const model = process.env.GOOGLE_MODEL || 'gemini-2.5-flash-lite'
     const response = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GOOGLE_API_KEY}`,
       {

--- a/app/api/diagnostics/google/route.ts
+++ b/app/api/diagnostics/google/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 
 export const runtime = 'nodejs'
 
-const DEFAULT_MODEL = process.env.GOOGLE_MODEL || 'gemini-1.5-flash-latest'
+const DEFAULT_MODEL = process.env.GOOGLE_MODEL || 'gemini-2.5-flash-lite'
 
 export async function GET() {
   if (!process.env.GOOGLE_API_KEY) {

--- a/app/api/diagnostics/google/route.ts
+++ b/app/api/diagnostics/google/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+
+const DEFAULT_MODEL = process.env.GOOGLE_MODEL || 'gemini-1.5-flash-latest'
+
+export async function GET() {
+  if (!process.env.GOOGLE_API_KEY) {
+    return NextResponse.json({
+      ok: false,
+      error: 'missing_google_key',
+      message: 'GOOGLE_API_KEY is not configured.',
+    })
+  }
+
+  const model = DEFAULT_MODEL
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GOOGLE_API_KEY}`
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'Reply with OK.' }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0,
+          maxOutputTokens: 8,
+        },
+      }),
+    })
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      const message =
+        typeof data?.error?.message === 'string'
+          ? data.error.message
+          : typeof data?.error === 'string'
+          ? data.error
+          : response.statusText || 'Google AI request failed.'
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'google_request_failed',
+          message,
+          status: response.status,
+          details: data?.error ?? null,
+          endpoint: 'models.generateContent',
+          model,
+        },
+        { status: response.status || 200 },
+      )
+    }
+
+    const candidate = data?.candidates?.[0] || {}
+    const reply =
+      candidate?.content?.parts?.map((part: any) => part?.text || '').filter(Boolean).join('\n') || ''
+
+    return NextResponse.json({
+      ok: true,
+      model: {
+        name: candidate?.model || data?.model || model,
+        version: data?.modelVersion || candidate?.modelVersion || null,
+      },
+      reply,
+      finishReason: candidate?.finishReason || null,
+      safety: candidate?.safetyRatings || data?.safetyRatings || null,
+      endpoint: 'models.generateContent',
+    })
+  } catch (err: any) {
+    const message = typeof err?.message === 'string' ? err.message : 'Google AI request failed.'
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'google_request_failed',
+        message,
+        status: null,
+        endpoint: 'models.generateContent',
+        model,
+      },
+      { status: 200 },
+    )
+  }
+}

--- a/app/api/diagnostics/openai/route.ts
+++ b/app/api/diagnostics/openai/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+import OpenAI from 'openai'
+
+export const runtime = 'nodejs'
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini'
+
+export async function GET() {
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json({
+      ok: false,
+      error: 'missing_openai_key',
+      message: 'OPENAI_API_KEY is not configured.',
+    })
+  }
+
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  const model = DEFAULT_MODEL
+
+  try {
+    const completion = await client.chat.completions.create({
+      model,
+      messages: [
+        { role: 'system', content: 'You are a diagnostics probe. Reply with OK.' },
+        { role: 'user', content: 'Respond with OK.' },
+      ],
+      max_tokens: 8,
+      temperature: 0,
+    })
+
+    const reply = completion.choices?.[0]?.message?.content?.trim() || ''
+
+    return NextResponse.json({
+      ok: true,
+      model: { id: completion.model },
+      reply,
+      usage: completion.usage || null,
+      finishReason: completion.choices?.[0]?.finish_reason || null,
+      endpoint: 'chat.completions',
+    })
+  } catch (err: any) {
+    const status = typeof err?.status === 'number' ? err.status : null
+    const message =
+      typeof err?.message === 'string'
+        ? err.message
+        : typeof err?.error?.message === 'string'
+        ? err.error.message
+        : 'OpenAI request failed.'
+    const details = err?.error ?? null
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'openai_request_failed',
+        message,
+        status,
+        details,
+        endpoint: 'chat.completions',
+        model,
+      },
+      { status: status && status >= 400 ? status : 200 },
+    )
+  }
+}

--- a/app/api/session/[id]/intro/route.ts
+++ b/app/api/session/[id]/intro/route.ts
@@ -130,7 +130,7 @@ export async function POST(_req: NextRequest, { params }: { params: { id: string
     parts.push({ text: questionText })
     parts.push({ text: 'Respond only with JSON in the format {"message":"...","question":"..."}.' })
 
-    const model = process.env.GOOGLE_MODEL || 'gemini-1.5-flash'
+    const model = process.env.GOOGLE_MODEL || 'gemini-2.5-flash-lite'
     const response = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GOOGLE_API_KEY}`,
       {

--- a/app/globals.css
+++ b/app/globals.css
@@ -171,7 +171,9 @@ a:hover {
   display: flex;
   flex-direction: column;
   gap: 28px;
-  align-items: center;
+  align-items: stretch;
+  width: min(100%, 860px);
+  margin: 0 auto;
 }
 
 .hero-card {
@@ -490,6 +492,7 @@ textarea.diagnostics-log {
   color: var(--muted);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
   resize: vertical;
+  width: 100%;
 }
 
 .diagnostics-card {

--- a/app/globals.css
+++ b/app/globals.css
@@ -182,6 +182,48 @@ a:hover {
   text-align: center;
 }
 
+.alert-banner {
+  width: 100%;
+  text-align: left;
+  border-radius: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: linear-gradient(135deg, rgba(254, 226, 226, 0.92), rgba(254, 202, 202, 0.82));
+  color: #7f1d1d;
+  box-shadow: 0 16px 40px rgba(127, 29, 29, 0.16);
+}
+
+.alert-banner__title {
+  font-weight: 700;
+  font-size: 15px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.alert-banner__message {
+  font-size: 14px;
+  line-height: 1.5;
+  margin-bottom: 6px;
+}
+
+.alert-banner__meta {
+  font-size: 12px;
+  color: rgba(127, 29, 29, 0.82);
+}
+
+.alert-banner__snippet {
+  margin-top: 10px;
+  border-radius: 14px;
+  padding: 10px 12px;
+  background: rgba(254, 226, 226, 0.75);
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .account-chip {
   font-size: 13px;
   color: var(--muted);
@@ -492,6 +534,12 @@ textarea.diagnostics-log {
   gap: 16px;
 }
 
+.diagnostics-provider-error {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .diagnostic-card {
   background: rgba(255, 255, 255, 0.86);
   border: 1px solid rgba(243, 203, 165, 0.7);
@@ -520,6 +568,24 @@ textarea.diagnostics-log {
   font-size: 14px;
   color: var(--muted);
   white-space: pre-wrap;
+}
+
+.diagnostic-meta {
+  margin-top: 8px;
+  font-size: 12px;
+  color: rgba(115, 74, 43, 0.75);
+}
+
+.diagnostic-snippet {
+  margin-top: 10px;
+  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(243, 203, 165, 0.6);
+  border-radius: 14px;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .diagnostics-foxes {

--- a/lib/audio-bridge.ts
+++ b/lib/audio-bridge.ts
@@ -1,7 +1,12 @@
 // Thin typed wrapper around the legacy JS audio helpers used on the client
 // This avoids TS build errors while reusing the proven implementation.
 
-export type RecordResult = { blob: Blob; durationMs: number }
+export type RecordResult = {
+  blob: Blob
+  durationMs: number
+  started: boolean
+  stopReason: string
+}
 
 async function getModule(): Promise<any> {
   // Dynamic import so it only loads client-side

--- a/lib/google-model.ts
+++ b/lib/google-model.ts
@@ -1,0 +1,23 @@
+export const GOOGLE_DEFAULT_MODEL = 'gemini-2.5-flash-lite'
+
+export function normalizeGoogleModel(raw?: string | null): string {
+  const fallback = GOOGLE_DEFAULT_MODEL
+  if (typeof raw !== 'string') return fallback
+  let value = raw.trim()
+  if (!value) return fallback
+
+  value = value.replace(/^models\//i, '')
+  value = value.replace(/:(generateContent|streamGenerateContent)$/i, '')
+  value = value.replace(/\?.*$/, '')
+
+  const lower = value.toLowerCase()
+  if (lower.startsWith('gemini-2.5-') && lower.endsWith('-latest')) {
+    value = value.slice(0, -'-latest'.length)
+  }
+
+  return value || fallback
+}
+
+export function resolveGoogleModel(raw?: string | null): string {
+  return normalizeGoogleModel(raw)
+}

--- a/lib/google-model.ts
+++ b/lib/google-model.ts
@@ -11,6 +11,9 @@ export function normalizeGoogleModel(raw?: string | null): string {
   value = value.replace(/\?.*$/, '')
 
   const lower = value.toLowerCase()
+  if (lower.startsWith('gemini-1.5')) {
+    return fallback
+  }
   if (lower.startsWith('gemini-2.5-') && lower.endsWith('-latest')) {
     value = value.slice(0, -'-latest'.length)
   }


### PR DESCRIPTION
## Summary
- surface provider API errors during turns with a hero banner and persist them for diagnostics review
- capture provider failure metadata in local storage, mark it resolved after a healthy turn, and replay it in the diagnostics view/log
- add styling for the new alert banner and diagnostics snippets so HTTP 4xx/5xx details are easy to read

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68da9c333e04832a87a8e6cd9d91207f