### PR TITLE
Add user handle selector to home page

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { listUserHandles } from '@/lib/data'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function GET() {
+  try {
+    const handles = await listUserHandles()
+    return NextResponse.json({ ok: true, handles })
+  } catch (err) {
+    console.warn('Failed to load user handles', err)
+    return NextResponse.json({ ok: false, handles: [] }, { status: 500 })
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -182,6 +182,27 @@ a:hover {
   text-align: center;
 }
 
+.user-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
+  width: 100%;
+  max-width: 280px;
+}
+
+.user-selector label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(115, 74, 43, 0.85);
+}
+
+.user-selector select {
+  width: 100%;
+}
+
 .account-chip {
   font-size: 13px;
   color: var(--muted);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { CSSProperties } from 'react'
+import type { CSSProperties, ChangeEvent } from 'react'
+import { useRouter } from 'next/navigation'
 import { useInterviewMachine } from '@/lib/machine'
 import { calibrateRMS, recordUntilSilence, blobToBase64 } from '@/lib/audio-bridge'
 import { createSessionRecorder, SessionRecorder } from '@/lib/session-recorder'
@@ -358,6 +359,7 @@ type AssistantPlayback = {
 export function Home({ userHandle }: { userHandle?: string }) {
   const normalizedHandle = normalizeHandle(userHandle)
   const displayHandle = userHandle?.trim() || null
+  const router = useRouter()
   const machineState = useInterviewMachine((state) => state.state)
   const debugLog = useInterviewMachine((state) => state.debugLog)
   const pushLog = useInterviewMachine((state) => state.pushLog)
@@ -367,6 +369,8 @@ export function Home({ userHandle }: { userHandle?: string }) {
   const [hasStarted, setHasStarted] = useState(false)
   const [finishRequested, setFinishRequested] = useState(false)
   const [manualStopRequested, setManualStopRequested] = useState(false)
+  const [availableHandles, setAvailableHandles] = useState<string[]>([])
+  const [selectedHandle, setSelectedHandle] = useState(() => normalizedHandle ?? '')
   const inTurnRef = useRef(false)
   const manualStopRef = useRef(false)
   const recorderRef = useRef<SessionRecorder | null>(null)
@@ -403,6 +407,58 @@ export function Home({ userHandle }: { userHandle?: string }) {
   useEffect(() => {
     finishRequestedRef.current = finishRequested
   }, [finishRequested])
+
+  useEffect(() => {
+    setSelectedHandle(normalizedHandle ?? '')
+  }, [normalizedHandle])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadHandles() {
+      let serverHandles: string[] = []
+      try {
+        const res = await fetch('/api/users', { cache: 'no-store' })
+        if (res.ok) {
+          const data = await res.json()
+          if (Array.isArray(data?.handles)) {
+            serverHandles = data.handles.filter((value) => typeof value === 'string')
+          }
+        }
+      } catch {}
+
+      let storedHandle: string | undefined
+      if (typeof window !== 'undefined') {
+        try {
+          storedHandle = normalizeHandle(window.localStorage.getItem(ACTIVE_USER_HANDLE_STORAGE_KEY))
+        } catch {}
+      }
+
+      const deduped = new Set<string>()
+      for (const handle of serverHandles) {
+        const normalized = normalizeHandle(handle)
+        if (normalized) {
+          deduped.add(normalized)
+        }
+      }
+      if (normalizedHandle) {
+        deduped.add(normalizedHandle)
+      }
+      if (storedHandle) {
+        deduped.add(storedHandle)
+      }
+
+      if (!cancelled) {
+        setAvailableHandles(Array.from(deduped).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)))
+      }
+    }
+
+    loadHandles()
+
+    return () => {
+      cancelled = true
+    }
+  }, [normalizedHandle])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -463,6 +519,31 @@ export function Home({ userHandle }: { userHandle?: string }) {
       cancelled = true
     }
   }, [normalizedHandle, pushLog])
+
+  const handleUserSelectChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const next = event.target.value
+      setSelectedHandle(next)
+
+      if (typeof window !== 'undefined') {
+        try {
+          if (next) {
+            window.localStorage.setItem(ACTIVE_USER_HANDLE_STORAGE_KEY, next)
+          } else {
+            window.localStorage.removeItem(ACTIVE_USER_HANDLE_STORAGE_KEY)
+          }
+        } catch {}
+      }
+
+      if ((next || '') === (normalizedHandle ?? '')) {
+        return
+      }
+
+      const target = buildScopedPath('/', next || undefined)
+      router.push(target)
+    },
+    [normalizedHandle, router],
+  )
 
   useEffect(() => {
     return () => {
@@ -1421,6 +1502,17 @@ export function Home({ userHandle }: { userHandle?: string }) {
   return (
     <main className="home-main">
       <div className="panel-card hero-card">
+        <div className="user-selector">
+          <label htmlFor="home-user-selector">Choose account</label>
+          <select id="home-user-selector" value={selectedHandle} onChange={handleUserSelectChange}>
+            <option value="">Personal archive</option>
+            {availableHandles.map((handle) => (
+              <option key={handle} value={handle}>
+                @{handle}
+              </option>
+            ))}
+          </select>
+        </div>
         {displayHandle && (
           <div className="account-chip">
             Account: <span className="highlight">@{displayHandle.toLowerCase()}</span>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -688,6 +688,18 @@ export async function listSessions(handle?: string | null): Promise<Session[]> {
   return Array.from(seen.values()).sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
 }
 
+export async function listUserHandles(): Promise<string[]> {
+  await ensureSessionMemoryHydrated().catch(() => undefined)
+  const handles = new Set<string>()
+  for (const session of mem.sessions.values()) {
+    const normalized = normalizeHandle(session.user_handle ?? undefined)
+    if (normalized) {
+      handles.add(normalized)
+    }
+  }
+  return Array.from(handles).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+}
+
 export type SessionMemorySnapshot = {
   id: string
   created_at: string


### PR DESCRIPTION
## Summary
- add a server route that exposes the list of remembered user handles
- fetch the handle list on the home screen and render a dropdown selector
- style the new selector so it fits with the existing hero card layout
- mark the user list endpoint and client fetch as uncached so the selector stays up to date

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dbe0d00e70832ab4cf3b69ab385772