### PR TITLE
Restore account selector on home page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -192,6 +192,67 @@ a:hover {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
+.account-select-card {
+  width: 100%;
+  align-self: stretch;
+}
+
+.account-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.account-selector__label {
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 16px;
+}
+
+.account-selector__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.account-selector__controls input {
+  flex: 1 1 220px;
+  min-width: 180px;
+}
+
+.account-selector__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.account-selector__hint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+button.chip-button {
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--muted);
+  border: 1px solid rgba(243, 203, 165, 0.8);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+button.chip-button:hover {
+  background: rgba(255, 247, 237, 0.92);
+  color: var(--ink);
+}
+
+button.chip-button:focus-visible {
+  outline: 2px solid rgba(255, 153, 51, 0.32);
+  outline-offset: 2px;
+}
+
 button {
   border: none;
   background: linear-gradient(135deg, var(--accent) 0%, #ffb454 55%, #ffa94d 100%);

--- a/lib/user-scope.ts
+++ b/lib/user-scope.ts
@@ -3,6 +3,7 @@ export const EMAIL_STORAGE_BASE_KEY = 'defaultEmail'
 export const EMAIL_ENABLED_STORAGE_BASE_KEY = 'sendSummaryEmails'
 export const DEMO_HISTORY_BASE_KEY = 'demoHistory'
 export const ACTIVE_USER_HANDLE_STORAGE_KEY = 'activeUserHandle'
+export const KNOWN_USER_HANDLES_STORAGE_KEY = 'knownUserHandles'
 export const DEFAULT_NOTIFY_EMAIL = 'a@sarva.co'
 
 const DEFAULT_SCOPE_KEY = '__default__'


### PR DESCRIPTION
## Summary
- Reintroduce a scoped account selector on the home page with stored handle shortcuts and navigation helpers.
- Persist and reuse known account handles via local storage so history, diagnostics, and settings links follow the selected user.
- Style the selector controls and chips to match the existing panel design.

## Testing
- Not run (per instructions).

------
https://chatgpt.com/codex/tasks/task_e_68db31128aac832abd2978c585a429e2