### PR TITLE
Switch blob storage to Supabase and add storage diagnostics

### DIFF
--- a/ENV_KEYS.txt
+++ b/ENV_KEYS.txt
@@ -1,7 +1,9 @@
-This app runs *without* any environment variables (demo mode). 
+This app runs *without* any environment variables (demo mode).
 If you want real storage/email/AI later, here are the keys:
 - OPENAI_API_KEY: optional; enables real follow-up generation
-- VERCEL_BLOB_READ_WRITE_TOKEN: optional; writes artifacts to Vercel Blob
+- SUPABASE_URL: required for Supabase-backed storage
+- SUPABASE_SERVICE_ROLE_KEY (or SUPABASE_SECRET_KEY/SUPABASE_ANON_KEY): required for storage access
+- SUPABASE_STORAGE_BUCKET (or SUPABASE_BUCKET): required; bucket that holds session artifacts
 - RESEND_API_KEY: optional; sends the summary email on finalize
 - DEFAULT_NOTIFY_EMAIL: server-side default recipient (fallback: a@sarva.co)
 - NEXT_PUBLIC_APP_NAME and patience knobs are optional for UI

--- a/ToDoLater.txt
+++ b/ToDoLater.txt
@@ -3,7 +3,7 @@ Conversation flow: detect TTS playback failures and surface a retry/continue con
 Conversation flow: add heartbeat timeout that finalizes or retries a turn if no "finalized" event arrives within N seconds
 Conversation flow: log per-turn state transitions and expose them in diagnostics so stuck turns can be diagnosed post-mortem
 Reinstate graceful end-intent handling with recap prompt
-Add robust blob storage with real VERCEL_BLOB_READ_WRITE_TOKEN
+Document Supabase storage provisioning and rotate service keys routinely
 Add email delivery via Resend/SendGrid with proper API keys
 History page: show per-turn audio and transcripts, support playback
 Resume from last session: seed opening with recap of last transcript

--- a/app/api/diagnostics/storage/route.ts
+++ b/app/api/diagnostics/storage/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { blobHealth, getBlobEnvironment } from '@/lib/blob'
+
+export async function GET() {
+  const env = getBlobEnvironment()
+  const health = await blobHealth()
+  const ok = env.provider === 'supabase' && env.configured && health.ok && health.mode === 'supabase'
+  const message = ok
+    ? 'Supabase storage configured and responding.'
+    : env.provider !== 'supabase'
+    ? 'Storage is running in in-memory fallback mode.'
+    : health.ok
+    ? 'Supabase storage configured but not returning expected mode.'
+    : `Supabase health check failed: ${health.reason || 'unknown error'}`
+
+  return NextResponse.json({ ok, env, health, message })
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from 'next/server'
-import { blobHealth } from '@/lib/blob'
+import { blobHealth, getBlobEnvironment } from '@/lib/blob'
 import { dbHealth } from '@/lib/data'
 import { areSummaryEmailsEnabled } from '@/lib/email'
 
 export async function GET() {
   const blob = await blobHealth()
   const db = await dbHealth()
+  const storageEnv = getBlobEnvironment()
   const env = {
     hasOpenAI: Boolean(process.env.OPENAI_API_KEY),
-    hasBlobToken: Boolean(process.env.VERCEL_BLOB_READ_WRITE_TOKEN),
+    hasSupabase: storageEnv.configured,
+    storageProvider: storageEnv.provider,
+    storageBucket: storageEnv.bucket ?? null,
     hasResend: Boolean(process.env.RESEND_API_KEY),
     emailsEnabled: areSummaryEmailsEnabled(),
     defaultEmail: process.env.DEFAULT_NOTIFY_EMAIL || 'a@sarva.co',

--- a/app/diagnostics/page.tsx
+++ b/app/diagnostics/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 
-type TestKey = 'health' | 'google' | 'openai' | 'smoke' | 'e2e' | 'email'
+type TestKey = 'health' | 'storage' | 'google' | 'openai' | 'smoke' | 'e2e' | 'email'
 type TestResult = { status: 'idle' | 'pending' | 'ok' | 'error'; message?: string }
 type FoxRecord = {
   id: string
@@ -44,6 +44,7 @@ const PROVIDER_ERROR_STORAGE_KEY = 'diagnostics:lastProviderError'
 
 const TEST_CONFIG: Record<TestKey, { label: string; path: string; method: 'GET' | 'POST' }> = {
   health: { label: 'Health check', path: '/api/health', method: 'GET' },
+  storage: { label: 'Storage check', path: '/api/diagnostics/storage', method: 'GET' },
   google: { label: 'Google AI API check', path: '/api/diagnostics/google', method: 'GET' },
   openai: { label: 'OpenAI API check', path: '/api/diagnostics/openai', method: 'GET' },
   smoke: { label: 'Smoke test', path: '/api/diagnostics/smoke', method: 'POST' },
@@ -51,11 +52,12 @@ const TEST_CONFIG: Record<TestKey, { label: string; path: string; method: 'GET' 
   email: { label: 'Email test', path: '/api/diagnostics/email', method: 'POST' },
 }
 
-const TEST_ORDER: TestKey[] = ['health', 'google', 'openai', 'smoke', 'e2e', 'email']
+const TEST_ORDER: TestKey[] = ['health', 'storage', 'google', 'openai', 'smoke', 'e2e', 'email']
 
 function initialResults(): Record<TestKey, TestResult> {
   return {
     health: { status: 'idle' },
+    storage: { status: 'idle' },
     google: { status: 'idle' },
     openai: { status: 'idle' },
     smoke: { status: 'idle' },
@@ -71,14 +73,29 @@ function formatSummary(key: TestKey, data: any): string {
     const env = data.env || {}
     const blob = data.blob || {}
     const db = data.db || {}
+    const storageLabel = env.hasSupabase
+      ? env.storageBucket
+        ? `supabase (${env.storageBucket})`
+        : env.storageProvider || 'supabase'
+      : env.storageProvider === 'memory'
+      ? 'memory fallback'
+      : env.storageProvider || 'unconfigured'
     const parts = [
       `OpenAI: ${env.hasOpenAI ? 'yes' : 'no'}`,
-      `Blob token: ${env.hasBlobToken ? 'yes' : 'no'}`,
+      `Storage: ${storageLabel}`,
       `Resend: ${env.hasResend ? 'yes' : 'no'}`,
     ]
-    if (blob) parts.push(`Blob check: ${blob.ok ? 'ok' : blob.reason || 'error'}`)
+    if (blob) parts.push(`Storage health: ${blob.ok ? 'ok' : blob.reason || 'error'}`)
     if (db) parts.push(`DB: ${db.ok ? db.mode || 'ok' : db.reason || 'error'}`)
     return parts.join(' · ')
+  }
+
+  if (key === 'storage') {
+    if (typeof data?.message === 'string') return data.message
+    if (data?.env?.provider === 'supabase' && data?.ok) return 'Supabase storage ready.'
+    if (data?.env?.provider === 'memory') return 'Using in-memory storage fallback.'
+    if (data?.health?.reason) return `Error: ${data.health.reason}`
+    return data?.ok ? 'Storage check passed' : 'Storage check failed'
   }
 
   if (key === 'google') {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,18 +4,52 @@ import { SiteNav } from './site-nav'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const commitSha =
-    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? ''
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ??
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    process.env.NEXT_PUBLIC_GIT_COMMIT_SHA ??
+    process.env.GIT_COMMIT_SHA ??
+    process.env.COMMIT_REF ??
+    process.env.RENDER_GIT_COMMIT ??
+    ''
   const commitMessage =
-    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_MESSAGE ?? process.env.VERCEL_GIT_COMMIT_MESSAGE ?? 'local changes'
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_MESSAGE ??
+    process.env.VERCEL_GIT_COMMIT_MESSAGE ??
+    process.env.NEXT_PUBLIC_GIT_COMMIT_MESSAGE ??
+    process.env.GIT_COMMIT_MESSAGE ??
+    process.env.COMMIT_MESSAGE ??
+    process.env.RENDER_GIT_COMMIT_MESSAGE ??
+    'local changes'
   const commitTimestamp =
-    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_TIMESTAMP ?? process.env.VERCEL_GIT_COMMIT_TIMESTAMP ?? null
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_TIMESTAMP ??
+    process.env.VERCEL_GIT_COMMIT_TIMESTAMP ??
+    process.env.NEXT_PUBLIC_GIT_COMMIT_TIMESTAMP ??
+    process.env.GIT_COMMIT_TIMESTAMP ??
+    process.env.DEPLOY_CREATED_AT ??
+    null
   const repoOwner =
-    process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER ?? process.env.VERCEL_GIT_REPO_OWNER ?? ''
+    process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER ??
+    process.env.VERCEL_GIT_REPO_OWNER ??
+    process.env.NEXT_PUBLIC_GIT_REPO_OWNER ??
+    process.env.GIT_REPO_OWNER ??
+    ''
   const repoSlug =
-    process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG ?? process.env.VERCEL_GIT_REPO_SLUG ?? ''
+    process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG ??
+    process.env.VERCEL_GIT_REPO_SLUG ??
+    process.env.NEXT_PUBLIC_GIT_REPO_SLUG ??
+    process.env.GIT_REPO_SLUG ??
+    ''
+
+  const githubRepo = process.env.GITHUB_REPOSITORY ?? process.env.NEXT_PUBLIC_GITHUB_REPOSITORY ?? ''
+  const [githubOwner, githubSlug] = githubRepo.includes('/') ? githubRepo.split('/', 2) : ['', '']
 
   const shortSha = commitSha ? commitSha.slice(0, 7) : 'local'
-  const commitUrl = commitSha && repoOwner && repoSlug ? `https://github.com/${repoOwner}/${repoSlug}/commit/${commitSha}` : null
+  const finalRepoOwner = repoOwner || githubOwner
+  const finalRepoSlug = repoSlug || githubSlug
+
+  const commitUrl =
+    commitSha && finalRepoOwner && finalRepoSlug
+      ? `https://github.com/${finalRepoOwner}/${finalRepoSlug}/commit/${commitSha}`
+      : null
 
   const easternFormatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York',

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -1,5 +1,4 @@
-import { list } from '@vercel/blob'
-import { getBlobToken } from './blob'
+import { getBlobEnvironment, listBlobs } from './blob'
 import { normalizeHandle } from './user-scope'
 
 type RawTurnBlob = { url: string; downloadUrl?: string; uploadedAt: string; name: string }
@@ -44,10 +43,10 @@ type SessionEntry = StoredSession & {
   artifacts: StoredArtifacts
 }
 
-function ensureToken() {
-  const token = getBlobToken()
-  if (!token) throw new Error('Missing VERCEL_BLOB_READ_WRITE_TOKEN or BLOB_READ_WRITE_TOKEN')
-  return token
+function ensureStorageConfigured() {
+  const env = getBlobEnvironment()
+  if (!env.configured) throw new Error('Supabase storage is not configured')
+  return env
 }
 
 function normalizeUploadedAt(uploadedAt: unknown): string {
@@ -68,7 +67,9 @@ async function enrich(entry: SessionEntry): Promise<StoredSession> {
 
   for (const turn of entry.turnBlobs) {
     try {
-      const resp = await fetch(turn.downloadUrl || turn.url)
+      const targetUrl = turn.downloadUrl || turn.url
+      if (!targetUrl) continue
+      const resp = await fetch(targetUrl)
       const json = await resp.json()
       const turnNumber = Number(json.turn) || turns.length + 1
       const created = json.createdAt || turn.uploadedAt || null
@@ -85,7 +86,7 @@ async function enrich(entry: SessionEntry): Promise<StoredSession> {
         assistantAudio: typeof json.assistantAudioUrl === 'string' ? json.assistantAudioUrl : null,
         assistantAudioDurationMs: Number(json.assistantAudioDurationMs) || 0,
 
-        manifest: turn.downloadUrl || turn.url,
+        manifest: targetUrl,
         transcript: typeof json.transcript === 'string' ? json.transcript : '',
         assistantReply: typeof json.assistantReply === 'string' ? json.assistantReply : '',
         durationMs: duration,
@@ -163,7 +164,7 @@ async function enrich(entry: SessionEntry): Promise<StoredSession> {
   }
 }
 
-function buildEntries(blobs: Awaited<ReturnType<typeof list>>['blobs']) {
+function buildEntries(blobs: Awaited<ReturnType<typeof listBlobs>>['blobs']) {
   const sessions = new Map<string, SessionEntry>()
 
   for (const blob of blobs) {
@@ -189,40 +190,44 @@ function buildEntries(blobs: Awaited<ReturnType<typeof list>>['blobs']) {
 
     if (/^turn-\d+\.json$/.test(name)) {
       const uploadedAt = normalizeUploadedAt(blob.uploadedAt)
-      existing.turnBlobs.push({ url: blob.url, downloadUrl: blob.downloadUrl, uploadedAt, name })
+      const url = blob.downloadUrl || blob.url
+      if (!url) continue
+      existing.turnBlobs.push({ url, downloadUrl: blob.downloadUrl, uploadedAt, name })
       if (!existing.latestUploadedAt || uploadedAt > existing.latestUploadedAt) {
         existing.latestUploadedAt = uploadedAt
       }
     }
 
     if (/^session-.+\.json$/.test(name)) {
-
       const manifestUrl = blob.downloadUrl || blob.url
       existing.manifestUrl = manifestUrl
-      existing.artifacts.session_manifest = manifestUrl
-
       const uploadedAt = normalizeUploadedAt(blob.uploadedAt)
-      if (!existing.latestUploadedAt || uploadedAt > existing.latestUploadedAt) {
+      if (uploadedAt && (!existing.latestUploadedAt || uploadedAt > existing.latestUploadedAt)) {
         existing.latestUploadedAt = uploadedAt
       }
     }
 
-    if (/^transcript-.+\.txt$/.test(name)) {
-      existing.artifacts.transcript_txt = blob.downloadUrl || blob.url
-    }
-
-    if (/^transcript-.+\.json$/.test(name)) {
-      existing.artifacts.transcript_json = blob.downloadUrl || blob.url
-    }
-
-
-    if (/^session-audio\./.test(name)) {
-      existing.artifacts.session_audio = blob.downloadUrl || blob.url
-    }
-
-
     sessions.set(id, existing)
   }
+
+  return Array.from(sessions.values())
+}
+
+export async function listSessions(): Promise<StoredSession[]> {
+  ensureStorageConfigured()
+  const { blobs } = await listBlobs({ prefix: 'sessions/', limit: 2000 })
+  const entries = buildEntries(blobs)
+  const sessions: StoredSession[] = []
+
+  for (const entry of entries) {
+    sessions.push(await enrich(entry))
+  }
+
+  sessions.sort((a, b) => {
+    const aTime = a.endedAt || a.startedAt || '0'
+    const bTime = b.endedAt || b.startedAt || '0'
+    return new Date(bTime).getTime() - new Date(aTime).getTime()
+  })
 
   return sessions
 }
@@ -233,11 +238,10 @@ export async function fetchStoredSessions({
   handle,
 }: { page?: number; limit?: number; handle?: string | null } = {}): Promise<{ items: StoredSession[] }> {
   try {
-    const token = ensureToken()
-    const { blobs } = await list({ prefix: 'sessions/', limit: 2000, token })
-    const sessions = buildEntries(blobs)
-
-    const sorted = Array.from(sessions.values()).sort(
+    ensureStorageConfigured()
+    const { blobs } = await listBlobs({ prefix: 'sessions/', limit: 2000 })
+    const entries = buildEntries(blobs)
+    const sorted = entries.sort(
       (a, b) => new Date(b.latestUploadedAt || '0').getTime() - new Date(a.latestUploadedAt || '0').getTime(),
     )
 
@@ -266,11 +270,11 @@ export async function fetchStoredSessions({
 
 export async function fetchStoredSession(id: string): Promise<StoredSession | undefined> {
   try {
-    const token = ensureToken()
-    const { blobs } = await list({ prefix: `sessions/${id}/`, limit: 2000, token })
+    ensureStorageConfigured()
+    const { blobs } = await listBlobs({ prefix: `sessions/${id}/`, limit: 2000 })
     if (!blobs.length) return undefined
     const entries = buildEntries(blobs)
-    const entry = entries.get(id)
+    const entry = entries.find((session) => session.sessionId === id)
     if (!entry) return undefined
     return await enrich(entry)
   } catch {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.1",
       "dependencies": {
         "@sendgrid/mail": "^7.7.0",
-        "@vercel/blob": "0.22.0",
+        "@supabase/supabase-js": "^2.58.0",
         "autoprefixer": "10.4.20",
         "lucide-react": "0.460.0",
         "next": "14.2.5",
@@ -501,14 +501,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1214,6 +1206,80 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1267,6 +1333,12 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1295,6 +1367,15 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -1679,19 +1760,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vercel/blob": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.22.0.tgz",
-      "integrity": "sha512-l0o5bN5ih1H1DG29goULMpCzNIoFI3knFYNFwvGN7iZhK9vltCdlDy77AmrFldRP5af02YczUkjSXWLHMrHStg==",
-      "dependencies": {
-        "async-retry": "1.3.3",
-        "bytes": "3.1.2",
-        "undici": "5.28.2"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.0",
@@ -2112,14 +2180,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dependencies": {
-        "retry": "0.13.1"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2288,14 +2348,6 @@
       },
       "engines": {
         "node": ">=10.16.0"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -6137,14 +6189,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7225,17 +7269,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "5.28.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -7752,6 +7785,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -11,29 +11,29 @@
     "test:ui": "playwright test"
   },
   "dependencies": {
+    "@sendgrid/mail": "^7.7.0",
+    "@supabase/supabase-js": "^2.58.0",
+    "autoprefixer": "10.4.20",
+    "lucide-react": "0.460.0",
     "next": "14.2.5",
+    "openai": "4.58.1",
+    "postcss": "8.4.41",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "zustand": "4.5.4",
-    "zod": "3.23.8",
-    "lucide-react": "0.460.0",
-    "tailwindcss": "3.4.7",
-    "postcss": "8.4.41",
-    "autoprefixer": "10.4.20",
-    "@vercel/blob": "0.22.0",
     "resend": "3.3.0",
-    "openai": "4.58.1",
-    "@sendgrid/mail": "^7.7.0"
+    "tailwindcss": "3.4.7",
+    "zod": "3.23.8",
+    "zustand": "4.5.4"
   },
   "devDependencies": {
+    "@playwright/test": "1.46.1",
     "@types/node": "20.11.30",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "typescript": "5.6.2",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
     "prettier": "3.3.3",
-    "vitest": "1.6.0",
-    "@playwright/test": "1.46.1"
+    "typescript": "5.6.2",
+    "vitest": "1.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace the Vercel Blob helper with a Supabase-backed storage client while retaining the in-memory fallback
- extend health checks, diagnostics UI, and add a dedicated storage check endpoint to confirm the migration
- update docs/tests to cover the new Supabase configuration and ensure URLs remain accessible

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dd26d2b680832a8258b6899599abe0