### PR TITLE
Surface storage diagnostics and add quick handle dropdown

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -221,6 +221,30 @@ a:hover {
   min-width: 180px;
 }
 
+.account-selector__dropdown {
+  appearance: none;
+  background-color: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(243, 203, 165, 0.8);
+  border-radius: 12px;
+  padding: 10px 36px 10px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+  min-width: 180px;
+  flex: 0 0 auto;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23925B2E' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 12px 8px;
+}
+
+.account-selector__dropdown:focus-visible {
+  outline: 2px solid rgba(255, 153, 51, 0.32);
+  outline-offset: 2px;
+}
+
 .account-selector__chips {
   display: flex;
   flex-wrap: wrap;
@@ -491,6 +515,71 @@ button.hero-button.is-stopping {
   font-size: 16px;
   color: var(--muted);
   max-width: 460px;
+}
+
+.storage-diagnostics {
+  margin-top: 24px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(255, 186, 102, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.storage-diagnostics__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.storage-diagnostics__title {
+  font-size: 15px;
+}
+
+.storage-diagnostics__badge {
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+
+.storage-diagnostics__badge--pending {
+  background: rgba(59, 130, 246, 0.16);
+  color: #2563eb;
+}
+
+.storage-diagnostics__badge--ok {
+  background: rgba(16, 185, 129, 0.16);
+  color: #047857;
+}
+
+.storage-diagnostics__badge--error {
+  background: rgba(248, 113, 113, 0.16);
+  color: #b91c1c;
+}
+
+.storage-diagnostics__provider {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.storage-diagnostics__message {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.storage-diagnostics__link {
+  align-self: flex-start;
+  font-size: 13px;
 }
 
 button.btn-large {


### PR DESCRIPTION
## Summary
- fetch storage diagnostics on the home page and show the provider/health status inline with a link to Diagnostics
- restore an explicit quick-select dropdown for known handles alongside the existing chips and datalist helpers
- style the new dropdown and storage card to match the hero panel aesthetics

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dd917ba9a8832abee1f2fc54ebbcdd