### PR TITLE
Guard Netlify blob metadata fields

### DIFF
--- a/lib/blob.ts
+++ b/lib/blob.ts
@@ -349,14 +349,22 @@ export async function putBlobFromBuffer(
   }
 
   const uploadedAt = new Date().toISOString()
+  const metadata: Record<string, string | number> = {
+    contentType,
+    uploadedAt,
+    size: buf.byteLength,
+  }
+
+  if (typeof cacheControl === 'string' && cacheControl.length) {
+    metadata.cacheControl = cacheControl
+  }
+
+  if (typeof options.cacheControlMaxAge === 'number' && Number.isFinite(options.cacheControlMaxAge)) {
+    metadata.cacheControlMaxAge = Math.max(0, Math.trunc(options.cacheControlMaxAge))
+  }
+
   await store.set(targetPath, buf, {
-    metadata: {
-      contentType,
-      uploadedAt,
-      size: buf.byteLength,
-      cacheControl,
-      cacheControlMaxAge: options.cacheControlMaxAge,
-    },
+    metadata,
   })
 
   const proxyUrl = buildProxyUrl(targetPath)


### PR DESCRIPTION
## Summary
- avoid sending undefined metadata keys to Netlify when writing blobs so uploads no longer fail

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ddd7415650832a8158a366a12a2c71