### PR TITLE
fix: allow Netlify slug fallback when slug resolution fails

### DIFF
--- a/docs/netlify-migration-guide.md
+++ b/docs/netlify-migration-guide.md
@@ -29,6 +29,8 @@ Add these values under **Site settings → Environment variables**:
 - `NETLIFY_BLOBS_STORE` (optional override; omit to use the default)
 - Optional overrides if you host the store elsewhere: `NETLIFY_BLOBS_API_URL`, `NETLIFY_BLOBS_EDGE_URL`, `NETLIFY_BLOBS_PUBLIC_BASE_URL`.
 
+> Tip: If you accidentally paste the site slug (for example `dadsbot`) instead of the UUID Site ID, the runtime will try to resolve it automatically before connecting to Netlify Blobs. When the token cannot look up the slug, the app keeps using the slug you provided (and logs a diagnostic hint), so your deploy still works while you retrieve the canonical Site ID.
+
 > Without the token or site ID the runtime falls back to the in-memory store. Diagnostics will warn with `mode: "memory"` until you add the secrets and redeploy.
 
 ## 4. Wire the AI + email providers

--- a/lib/blob.ts
+++ b/lib/blob.ts
@@ -32,6 +32,8 @@ type NetlifyConfig = {
   edgeUrl?: string
   uncachedEdgeUrl?: string
   consistency?: 'strong' | 'eventual'
+  siteSlug?: string
+  siteName?: string
 }
 
 type CandidateSource = 'env' | 'context' | 'default'
@@ -78,6 +80,8 @@ type BlobErrorDetails = {
   target?: string
   store?: string
   siteId?: string
+  siteSlug?: string
+  siteName?: string
   tokenSource?: string
   tokenLength?: number
   usingContext?: boolean
@@ -121,6 +125,8 @@ type ReadBlobResult = {
 
 const GLOBAL_STORE_KEY = '__dads_interview_blob_fallback__'
 const BLOB_PROXY_PREFIX = '/api/blob/'
+const NETLIFY_API_BASE_URL = 'https://api.netlify.com'
+const CANONICAL_SITE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 const globalAny = globalThis as any
 if (!globalAny[GLOBAL_STORE_KEY]) {
@@ -133,6 +139,16 @@ let netlifyConfig: NetlifyConfig | null | undefined
 let netlifyStore: Store | null | undefined
 let netlifyWarningIssued = false
 let netlifyDiagnostics: BlobEnvDiagnostics | null | undefined
+let netlifySiteResolution: Promise<SiteResolution | null> | null = null
+let netlifySiteResolutionSlug: string | null = null
+let netlifySiteResolutionNotified = false
+let netlifySiteResolutionFallbackNotifiedSlug: string | null = null
+
+type SiteResolution = {
+  slug: string
+  siteId: string
+  siteName?: string
+}
 
 function defaultDiagnostics(): BlobEnvDiagnostics {
   return {
@@ -176,6 +192,197 @@ function truncateForDiagnostics(value: string, limit = 240) {
   if (!cleaned.length) return ''
   if (cleaned.length <= limit) return cleaned
   return `${cleaned.slice(0, limit - 1)}…`
+}
+
+function looksLikeSiteId(value: string): boolean {
+  return CANONICAL_SITE_ID.test(value.trim())
+}
+
+async function resolveSiteId(config: NetlifyConfig): Promise<SiteResolution | null> {
+  const slug = config.siteId.trim()
+  if (!slug.length) return null
+  const token = config.token.trim()
+  if (!token.length) return null
+  const base = (config.apiUrl || '').trim() || NETLIFY_API_BASE_URL
+  const url = new URL(`/api/v1/sites/${encodeURIComponent(slug)}`, base)
+
+  if (typeof fetch !== 'function') {
+    throw new Error('Global fetch implementation is required to resolve Netlify site slugs.')
+  }
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'user-agent': 'dads-interview-bot/slug-resolver',
+    },
+  })
+
+  if (response.status === 404) {
+    return null
+  }
+
+  if (!response.ok) {
+    let snippet: string | undefined
+    try {
+      const text = await response.text()
+      if (text && text.trim().length) {
+        snippet = truncateForDiagnostics(text, 160)
+      }
+    } catch {}
+    const summary = snippet ? `: ${snippet}` : ''
+    throw new Error(`Failed to resolve Netlify site slug "${slug}" (status ${response.status})${summary}`)
+  }
+
+  let payload: any
+  try {
+    payload = await response.json()
+  } catch (error) {
+    throw new Error(`Resolved Netlify site slug "${slug}" but failed to parse response JSON: ${(error as Error).message}`)
+  }
+
+  const rawId = typeof payload?.id === 'string' ? payload.id.trim() : ''
+  if (!looksLikeSiteId(rawId)) {
+    throw new Error(
+      `Netlify site lookup for slug "${slug}" returned an unexpected site identifier. Expected a UUID but received "${rawId}".`,
+    )
+  }
+
+  const siteName =
+    typeof payload?.name === 'string' && payload.name.trim().length
+      ? payload.name.trim()
+      : typeof payload?.site_name === 'string' && payload.site_name.trim().length
+      ? payload.site_name.trim()
+      : undefined
+
+  return { slug, siteId: rawId, siteName }
+}
+
+async function ensureCanonicalSiteId(config: NetlifyConfig): Promise<NetlifyConfig> {
+  if (looksLikeSiteId(config.siteId)) {
+    if (!config.siteSlug) {
+      return config
+    }
+    return { ...config }
+  }
+
+  if (!netlifySiteResolution || netlifySiteResolutionSlug !== config.siteId) {
+    netlifySiteResolutionSlug = config.siteId
+    netlifySiteResolution = resolveSiteId(config)
+  }
+
+  let resolution: SiteResolution | null = null
+  try {
+    resolution = await netlifySiteResolution
+  } catch (error) {
+    netlifySiteResolution = Promise.resolve(null)
+    const reason = error instanceof Error ? error.message : undefined
+    recordSiteSlugFallback(config.siteId, reason)
+    notifySiteResolutionFallback(config.siteId, reason)
+    const fallback: NetlifyConfig = { ...config, siteSlug: config.siteId }
+    netlifyConfig = fallback
+    return fallback
+  }
+
+  if (!resolution) {
+    recordSiteSlugFallback(config.siteId, 'resolution unavailable; using provided slug')
+    notifySiteResolutionFallback(config.siteId, 'Netlify API returned no site record for the slug or access is restricted.')
+    const fallback: NetlifyConfig = { ...config, siteSlug: config.siteId }
+    netlifyConfig = fallback
+    return fallback
+  }
+
+  const updated: NetlifyConfig = {
+    ...config,
+    siteId: resolution.siteId,
+    siteSlug: resolution.slug,
+    siteName: resolution.siteName,
+  }
+
+  netlifyConfig = updated
+  updateDiagnosticsForResolution(resolution)
+  notifySiteResolution(resolution)
+
+  return updated
+}
+
+function updateDiagnosticsForResolution(resolution: SiteResolution) {
+  if (!netlifyDiagnostics) return
+  const noteParts = [`resolved slug "${resolution.slug}" to site ID ${maskValue(resolution.siteId)}`]
+  if (resolution.siteName && resolution.siteName !== resolution.slug) {
+    noteParts.push(`(${resolution.siteName})`)
+  }
+  const note = noteParts.join(' ')
+  if (netlifyDiagnostics.siteId.selected) {
+    netlifyDiagnostics.siteId.selected = {
+      ...netlifyDiagnostics.siteId.selected,
+      valuePreview: maskValue(resolution.siteId),
+      note: netlifyDiagnostics.siteId.selected.note
+        ? `${netlifyDiagnostics.siteId.selected.note}; ${note}`
+        : note,
+    }
+  }
+  netlifyDiagnostics.siteId.present = true
+  netlifyDiagnostics.missing = netlifyDiagnostics.missing.filter((entry) => entry !== 'siteId')
+}
+
+function notifySiteResolution(resolution: SiteResolution) {
+  if (netlifySiteResolutionNotified) return
+  netlifySiteResolutionNotified = true
+  flagFox({
+    id: 'netlify-site-slug-resolved',
+    theory: 2,
+    level: 'info',
+    message: `Resolved Netlify site slug "${resolution.slug}" to site ID ${maskValue(resolution.siteId)} for blob storage.`,
+    details: {
+      siteSlug: resolution.slug,
+      siteId: maskValue(resolution.siteId),
+      siteName: resolution.siteName,
+    },
+  })
+}
+
+function recordSiteSlugFallback(slug: string, reason?: string) {
+  if (!netlifyDiagnostics) return
+  const noteParts = [`using site slug "${slug}" for Netlify blob access`]
+  if (reason) {
+    const cleaned = truncateForDiagnostics(reason, 160)
+    if (cleaned.length) {
+      noteParts.push(`(${cleaned})`)
+    }
+  }
+  const note = noteParts.join(' ')
+  if (netlifyDiagnostics.siteId.selected) {
+    const selected = netlifyDiagnostics.siteId.selected
+    const preview = selected.valuePreview && selected.valuePreview.length ? selected.valuePreview : slug
+    netlifyDiagnostics.siteId.selected = {
+      ...selected,
+      valuePreview: preview,
+      note: selected.note ? `${selected.note}; ${note}` : note,
+    }
+  }
+  netlifyDiagnostics.siteId.present = true
+  netlifyDiagnostics.missing = netlifyDiagnostics.missing.filter((entry) => entry !== 'siteId')
+}
+
+function notifySiteResolutionFallback(slug: string, reason?: string) {
+  if (netlifySiteResolutionFallbackNotifiedSlug === slug) return
+  netlifySiteResolutionFallbackNotifiedSlug = slug
+  const cleanedReason = reason ? truncateForDiagnostics(reason, 160) : undefined
+  const messageParts = [`Continuing to use Netlify site slug "${slug}" for blob storage.`]
+  if (cleanedReason) {
+    messageParts.push(cleanedReason)
+  }
+  flagFox({
+    id: 'netlify-site-slug-fallback',
+    theory: 2,
+    level: 'info',
+    message: messageParts.join(' '),
+    details: {
+      siteSlug: slug,
+      reason: cleanedReason,
+    },
+  })
 }
 
 function extractStatusCode(error: any): number | undefined {
@@ -300,6 +507,8 @@ async function buildBlobError(
     target: context.target,
     store: config?.storeName,
     siteId: config?.siteId,
+    siteSlug: config?.siteSlug,
+    siteName: config?.siteName,
     tokenSource: diagnostics.token.selected?.key,
     tokenLength: diagnostics.token.length,
     usingContext: diagnostics.usingContext,
@@ -596,9 +805,11 @@ function getBlobEnvDiagnostics(): BlobEnvDiagnostics {
   return netlifyDiagnostics ?? defaultDiagnostics()
 }
 
-function getNetlifyStore(): Store | null {
-  const config = getNetlifyConfig()
-  if (!config) return null
+async function getNetlifyStore(): Promise<Store | null> {
+  const baseConfig = getNetlifyConfig()
+  if (!baseConfig) return null
+
+  const config = await ensureCanonicalSiteId(baseConfig)
 
   if (!netlifyStore) {
     netlifyStore = getStore({
@@ -714,7 +925,7 @@ export async function putBlobFromBuffer(
   contentType: string,
   options: PutBlobOptions = {},
 ) {
-  const store = getNetlifyStore()
+  const store = await getNetlifyStore()
   let targetPath = normalizePath(path)
   if (options.addRandomSuffix) {
     targetPath = applyRandomSuffix(targetPath)
@@ -789,7 +1000,7 @@ export async function listBlobs(options: ListCommandOptions = {}): Promise<ListB
   const limit = typeof options?.limit === 'number' ? Math.max(1, options.limit) : 100
   const offset = options?.cursor ? Number.parseInt(options.cursor, 10) || 0 : 0
 
-  const store = getNetlifyStore()
+  const store = await getNetlifyStore()
   if (!store) {
     const fallback = await listFallbackBlobs({ prefix })
     const sliced = fallback.slice(offset, offset + limit)
@@ -861,7 +1072,7 @@ export async function listBlobs(options: ListCommandOptions = {}): Promise<ListB
 }
 
 export async function deleteBlobsByPrefix(prefix: string): Promise<number> {
-  const store = getNetlifyStore()
+  const store = await getNetlifyStore()
   const sanitizedPrefix = normalizePath(prefix)
 
   if (!store) {
@@ -904,7 +1115,7 @@ export async function deleteBlobsByPrefix(prefix: string): Promise<number> {
 export async function deleteBlob(pathOrUrl: string): Promise<boolean> {
   if (!pathOrUrl) return false
 
-  const store = getNetlifyStore()
+  const store = await getNetlifyStore()
 
   if (!store) {
     if (memoryStore.delete(pathOrUrl) || memoryStore.delete(normalizePath(pathOrUrl))) {
@@ -954,7 +1165,7 @@ export async function readBlob(pathOrUrl: string): Promise<ReadBlobResult | null
     return null
   }
 
-  const store = getNetlifyStore()
+  const store = await getNetlifyStore()
   if (!store) {
     const record = memoryStore.get(pathOrUrl) || memoryStore.get(normalizePath(pathOrUrl))
     if (!record) return null
@@ -1017,7 +1228,7 @@ export async function blobHealth() {
   }
 
   try {
-    const store = getNetlifyStore()
+    const store = await getNetlifyStore()
     if (!store) {
       return { ok: false, mode: 'netlify', reason: 'failed to initialize store' }
     }
@@ -1048,6 +1259,8 @@ export function getBlobEnvironment() {
     configured: true as const,
     store: config.storeName,
     siteId: config.siteId,
+    siteSlug: config.siteSlug,
+    siteName: config.siteName,
     diagnostics,
   }
 }

--- a/tests/blob.test.ts
+++ b/tests/blob.test.ts
@@ -7,11 +7,12 @@ afterEach(() => {
   delete process.env.NETLIFY_BLOBS_CONTEXT
   vi.resetModules()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('putBlobFromBuffer', () => {
   it('uploads via Netlify when credentials are provided', async () => {
-    process.env.NETLIFY_BLOBS_SITE_ID = 'site-id'
+    process.env.NETLIFY_BLOBS_SITE_ID = '12345678-1234-1234-1234-1234567890ab'
     process.env.NETLIFY_BLOBS_TOKEN = 'api-token'
     process.env.NETLIFY_BLOBS_STORE = 'store-name'
 
@@ -32,7 +33,7 @@ describe('putBlobFromBuffer', () => {
 
     expect(getStoreSpy).toHaveBeenCalledWith({
       name: 'store-name',
-      siteID: 'site-id',
+      siteID: '12345678-1234-1234-1234-1234567890ab',
       token: 'api-token',
       apiURL: undefined,
       edgeURL: undefined,
@@ -52,6 +53,72 @@ describe('putBlobFromBuffer', () => {
     expect(result.url.startsWith('data:text/plain;base64,')).toBe(true)
     expect(result.downloadUrl).toBe(result.url)
   })
+})
+
+it('resolves a site slug to the canonical Netlify site ID', async () => {
+  process.env.NETLIFY_BLOBS_SITE_ID = 'dadsbot'
+  process.env.NETLIFY_BLOBS_TOKEN = 'api-token'
+
+  const setSpy = vi.fn(async () => ({}))
+  const storeMock = {
+    set: setSpy,
+    list: vi.fn(async () => ({ blobs: [] })),
+    getMetadata: vi.fn(async () => null),
+    delete: vi.fn(async () => {}),
+    getWithMetadata: vi.fn(async () => null),
+  }
+
+  const getStoreSpy = vi.fn(() => storeMock)
+  const fetchSpy = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ id: '98765432-4321-4321-4321-ba0987654321', name: 'dadsbot-site' }),
+  }))
+  vi.stubGlobal('fetch', fetchSpy)
+
+  vi.doMock('@netlify/blobs', () => ({ getStore: getStoreSpy }))
+
+  const { putBlobFromBuffer } = await import('../lib/blob')
+  await putBlobFromBuffer('path/file.txt', Buffer.from('hello'), 'text/plain')
+
+  expect(fetchSpy).toHaveBeenCalledWith(
+    expect.stringContaining('/api/v1/sites/dadsbot'),
+    expect.objectContaining({ method: 'GET' }),
+  )
+
+  expect(getStoreSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ siteID: '98765432-4321-4321-4321-ba0987654321' }),
+  )
+})
+
+it('falls back to the provided slug when resolution is unavailable', async () => {
+  process.env.NETLIFY_BLOBS_SITE_ID = 'dadsbot'
+  process.env.NETLIFY_BLOBS_TOKEN = 'api-token'
+
+  const setSpy = vi.fn(async () => ({}))
+  const storeMock = {
+    set: setSpy,
+    list: vi.fn(async () => ({ blobs: [] })),
+    getMetadata: vi.fn(async () => null),
+    delete: vi.fn(async () => {}),
+    getWithMetadata: vi.fn(async () => null),
+  }
+
+  const getStoreSpy = vi.fn(() => storeMock)
+  const fetchSpy = vi.fn(async () => ({
+    ok: false,
+    status: 404,
+    text: async () => '',
+  }))
+  vi.stubGlobal('fetch', fetchSpy)
+
+  vi.doMock('@netlify/blobs', () => ({ getStore: getStoreSpy }))
+
+  const { putBlobFromBuffer } = await import('../lib/blob')
+  await putBlobFromBuffer('path/file.txt', Buffer.from('hello'), 'text/plain')
+
+  expect(fetchSpy).toHaveBeenCalled()
+  expect(getStoreSpy).toHaveBeenCalledWith(expect.objectContaining({ siteID: 'dadsbot' }))
 })
 
 describe('listBlobs', () => {


### PR DESCRIPTION
## Summary
- allow Netlify blob setup to continue when only a site slug is provided by recording diagnostics and using the slug as-is
- surface slug fallback information through fox flags and documentation so deployments get clear guidance
- cover slug fallback behaviour with a regression unit test alongside the existing slug-resolution test

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e03c19db14832ab8d8487fb947e747