### PR TITLE
Support Netlify-managed blob tokens

### DIFF
--- a/app/diagnostics/page.tsx
+++ b/app/diagnostics/page.tsx
@@ -39,6 +39,17 @@ type ProviderErrorSynopsis = {
   resolvedAt?: string
 }
 
+type DeploymentSnapshot = {
+  origin?: string
+  host?: string
+  href?: string
+  pathname?: string
+  releaseId?: string
+  vercelEnv?: string
+  vercelUrl?: string
+  netlifySiteUrl?: string
+}
+
 const TRANSCRIPT_STORAGE_KEY = 'diagnostics:lastTranscript'
 const PROVIDER_ERROR_STORAGE_KEY = 'diagnostics:lastProviderError'
 
@@ -87,8 +98,34 @@ function describeBlobDetails(raw: any): string[] {
   } else if (typeof details.siteId === 'string' && details.siteId.length) {
     parts.push(`site ${details.siteId}`)
   }
+  if (typeof details.tokenSource === 'string' && details.tokenSource.length) {
+    parts.push(`token from ${details.tokenSource}`)
+  }
+  if (typeof details.tokenLength === 'number' && Number.isFinite(details.tokenLength)) {
+    parts.push(`token length ${details.tokenLength}`)
+  }
   if (Array.isArray(details.missing) && details.missing.length) {
-    parts.push(`missing ${details.missing.join(', ')}`)
+    const missingLabels = details.missing
+      .filter(
+        (item: unknown): item is string => typeof item === 'string' && item.length > 0,
+      )
+      .join(', ')
+    if (missingLabels.length) {
+      parts.push(`missing ${missingLabels}`)
+    }
+  }
+  if (typeof details.usingContext === 'boolean') {
+    parts.push(details.usingContext ? 'context payload detected' : 'context payload missing')
+  }
+  if (Array.isArray(details.contextKeys) && details.contextKeys.length) {
+    const contextKeys = details.contextKeys
+      .filter(
+        (item: unknown): item is string => typeof item === 'string' && item.length > 0,
+      )
+      .slice(0, 4)
+    if (contextKeys.length) {
+      parts.push(`context keys ${contextKeys.join(', ')}`)
+    }
   }
   if (typeof details.status === 'number' && Number.isFinite(details.status)) {
     parts.push(`status ${details.status}`)
@@ -107,6 +144,156 @@ function describeBlobDetails(raw: any): string[] {
   }
 
   return parts
+}
+
+function readDeploymentSnapshot(): DeploymentSnapshot | null {
+  if (typeof window === 'undefined') return null
+
+  const snapshot: DeploymentSnapshot = {}
+  const { location } = window
+
+  if (location) {
+    if (typeof location.origin === 'string' && location.origin.length) {
+      snapshot.origin = location.origin
+    }
+    if (typeof location.host === 'string' && location.host.length) {
+      snapshot.host = location.host
+    }
+    if (typeof location.href === 'string' && location.href.length) {
+      snapshot.href = location.href
+    }
+    if (typeof location.pathname === 'string' && location.pathname.length) {
+      snapshot.pathname = location.pathname
+    }
+  }
+
+  const nextData = (window as any).__NEXT_DATA__
+  if (nextData && typeof nextData === 'object') {
+    if (typeof nextData.buildId === 'string' && nextData.buildId.length) {
+      snapshot.releaseId = nextData.buildId
+    }
+  }
+
+  const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV
+  if (typeof vercelEnv === 'string' && vercelEnv.length) {
+    snapshot.vercelEnv = vercelEnv
+  }
+
+  const vercelUrl =
+    process.env.NEXT_PUBLIC_VERCEL_URL ??
+    process.env.NEXT_PUBLIC_DEPLOYMENT_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL
+  if (typeof vercelUrl === 'string' && vercelUrl.length) {
+    snapshot.vercelUrl = vercelUrl
+  }
+
+  const netlifySiteUrl = process.env.NEXT_PUBLIC_NETLIFY_SITE_URL
+  if (typeof netlifySiteUrl === 'string' && netlifySiteUrl.length) {
+    snapshot.netlifySiteUrl = netlifySiteUrl
+  }
+
+  return snapshot
+}
+
+function summarizeNetlifyDiagnostics(raw: any, deployment?: DeploymentSnapshot | null): string[] {
+  if (!raw || typeof raw !== 'object') return []
+  const summary: string[] = []
+
+  const tokenPresent = raw?.token?.present === true
+  const tokenKeyCandidate = raw?.token?.selected?.key
+  const tokenSource =
+    typeof tokenKeyCandidate === 'string' && tokenKeyCandidate.length ? tokenKeyCandidate : undefined
+  const tokenLabel = tokenPresent
+    ? `present${tokenSource ? ` from ${tokenSource}` : ''}`
+    : raw?.token?.present === false
+    ? 'missing'
+    : 'unknown'
+
+  const storePreviewCandidate = raw?.store?.selected?.valuePreview ?? raw?.store?.selected?.value
+  const storePreview =
+    typeof storePreviewCandidate === 'string' && storePreviewCandidate.length
+      ? storePreviewCandidate
+      : undefined
+  const storeDefaulted = raw?.store?.defaulted === true
+  const storeLabel = storePreview
+    ? `${storePreview}${storeDefaulted ? ' (defaulted)' : ''}`
+    : storeDefaulted
+    ? 'defaulted (value unknown)'
+    : 'unresolved'
+
+  const sitePreviewCandidate = raw?.siteId?.selected?.valuePreview ?? raw?.siteId?.selected?.value
+  const sitePreview =
+    typeof sitePreviewCandidate === 'string' && sitePreviewCandidate.length
+      ? sitePreviewCandidate
+      : undefined
+  const sitePresent = raw?.siteId?.present === true
+  const siteLabel = sitePresent
+    ? `${sitePreview || 'value provided'}${raw?.siteId?.defaulted ? ' (defaulted)' : ''}`
+    : raw?.siteId?.present === false
+    ? 'missing'
+    : 'unknown'
+
+  const overrides: string[] = []
+  const warnings: string[] = []
+  const edgeUrlCandidate = raw?.optional?.edgeUrl?.selected?.valuePreview
+  const apiUrlCandidate = raw?.optional?.apiUrl?.selected?.valuePreview
+  const uncachedEdgeUrlCandidate = raw?.optional?.uncachedEdgeUrl?.selected?.valuePreview
+  const edgeUrl = typeof edgeUrlCandidate === 'string' && edgeUrlCandidate.length ? edgeUrlCandidate : undefined
+  const edgeNoteCandidate = raw?.optional?.edgeUrl?.selected?.note
+  const apiUrl = typeof apiUrlCandidate === 'string' && apiUrlCandidate.length ? apiUrlCandidate : undefined
+  const uncachedEdgeUrl =
+    typeof uncachedEdgeUrlCandidate === 'string' && uncachedEdgeUrlCandidate.length
+      ? uncachedEdgeUrlCandidate
+      : undefined
+
+  if (edgeUrl) overrides.push(`edge=${edgeUrl}`)
+  if (uncachedEdgeUrl) overrides.push(`uncached_edge=${uncachedEdgeUrl}`)
+  if (apiUrl) overrides.push(`api=${apiUrl}`)
+
+  if (edgeUrl && /^https?:\/\/netlify-blobs\.netlify\.app/i.test(edgeUrl)) {
+    warnings.push('Edge override points at netlify-blobs.netlify.app; remove or switch to the API host for writes')
+  }
+  if (edgeUrl && !apiUrl) {
+    warnings.push('Edge override is set without NETLIFY_BLOBS_API_URL; uploads will target the edge host')
+  }
+  if (typeof edgeNoteCandidate === 'string' && /suppressed for uploads/i.test(edgeNoteCandidate)) {
+    warnings.push('Edge override sanitized for uploads to avoid Netlify blob 405 errors')
+  }
+
+  summary.push(`Store: ${storeLabel}`)
+  summary.push(`Token: ${tokenLabel}`)
+  summary.push(`Site ID: ${siteLabel}`)
+  summary.push(`Overrides: ${overrides.length ? overrides.join(' · ') : 'none set'}`)
+  if (warnings.length) {
+    summary.push(`Warnings: ${warnings.join(' · ')}`)
+  }
+
+  if (deployment) {
+    const originLabel = deployment.origin || deployment.host
+    if (originLabel) {
+      summary.push(`Deployment origin: ${originLabel}`)
+    }
+    if (deployment.href) {
+      summary.push(`Deployment URL: ${deployment.href}`)
+    }
+    if (deployment.pathname) {
+      summary.push(`Deployment path: ${deployment.pathname}`)
+    }
+    if (deployment.vercelEnv) {
+      summary.push(`Runtime env: ${deployment.vercelEnv}`)
+    }
+    if (deployment.vercelUrl && (!deployment.origin || !deployment.origin.includes(deployment.vercelUrl))) {
+      summary.push(`Vercel URL: ${deployment.vercelUrl}`)
+    }
+    if (deployment.netlifySiteUrl) {
+      summary.push(`Netlify site URL: ${deployment.netlifySiteUrl}`)
+    }
+    if (deployment.releaseId) {
+      summary.push(`Build ID: ${deployment.releaseId}`)
+    }
+  }
+
+  return summary
 }
 
 function formatSummary(key: TestKey, data: any): string {
@@ -469,11 +656,38 @@ export default function DiagnosticsPage() {
       } catch {}
     }
 
+    const deploymentSnapshot = readDeploymentSnapshot()
+
     setLatestTranscript(transcriptSnapshot)
     if (providerSnapshot) {
       setLatestProviderError(providerSnapshot)
     } else {
       setLatestProviderError(null)
+    }
+
+    if (deploymentSnapshot) {
+      const originLabel = deploymentSnapshot.origin || deploymentSnapshot.host || 'origin unknown'
+      append(`[deployment] Origin: ${originLabel}`)
+      if (deploymentSnapshot.href) {
+        append(`[deployment] URL: ${deploymentSnapshot.href}`)
+      }
+      if (deploymentSnapshot.pathname) {
+        append(`[deployment] Path: ${deploymentSnapshot.pathname}`)
+      }
+      if (deploymentSnapshot.vercelEnv) {
+        append(`[deployment] Runtime env: ${deploymentSnapshot.vercelEnv}`)
+      }
+      if (deploymentSnapshot.vercelUrl) {
+        append(`[deployment] Vercel URL: ${deploymentSnapshot.vercelUrl}`)
+      }
+      if (deploymentSnapshot.netlifySiteUrl) {
+        append(`[deployment] Netlify site URL: ${deploymentSnapshot.netlifySiteUrl}`)
+      }
+      if (deploymentSnapshot.releaseId) {
+        append(`[deployment] Build ID: ${deploymentSnapshot.releaseId}`)
+      }
+    } else {
+      append('[deployment] Unable to determine current deployment origin from browser context.')
     }
 
     if (transcriptSnapshot) {
@@ -548,6 +762,14 @@ export default function DiagnosticsPage() {
           const ok = typeof parsed.ok === 'boolean' ? parsed.ok : res.ok
           const message = formatSummary(key, parsed)
           updateResult(key, { status: ok ? 'ok' : 'error', message })
+          if (key === 'storage') {
+            const diagnosticsSummary = summarizeNetlifyDiagnostics(parsed?.env?.diagnostics, deploymentSnapshot)
+            if (diagnosticsSummary.length) {
+              append('***KEY NETFLIFY ITEMS***')
+              diagnosticsSummary.forEach(line => append(line))
+              append('***KEY NETFLIFY ITEMS***')
+            }
+          }
         } else {
           append(rawText || '(no response body)')
           updateResult(key, {

--- a/docs/netlify-blob-config.md
+++ b/docs/netlify-blob-config.md
@@ -1,0 +1,45 @@
+# Netlify Blob Storage Configuration Checklist
+
+Use this walkthrough to verify the blob configuration items that cause 405 errors when uploads run from the app. Complete each step in order so you know the store, token, and site wiring all match.
+
+## 1. Confirm the blob store exists and matches the configured name
+1. Sign in to [Netlify](https://app.netlify.com/) and open your team dashboard.
+2. In the global navigation, choose **Storage** ➜ **Blobs**. (If the Storage item is hidden, open **Team settings** first, then choose **Storage** from the left-hand sidebar.)
+3. Locate the store named `dads-interview-bot`. If it is missing, click **Create blob store**, enter `dads-interview-bot`, and finish the wizard. If you already use a different store name, note the exact value—you must copy it into `NETLIFY_BLOBS_STORE`.
+4. When the store is present, open it and copy its **Store name** and **Store ID** for reference.
+
+## 2. Generate a token with blob write scope
+1. While still in the Netlify app, click your avatar (top-right) and choose **User settings**.
+2. Go to **Applications** ➜ **Personal access tokens**, then press **New access token**.
+3. Give the token a descriptive label (for example, “Dads Interview Bot Blobs”).
+4. In the scopes list, enable **Blobs: Read and write** (or **Full access** if you prefer), then create the token.
+5. Copy the generated token immediately. In your deployment environment, set the `NETLIFY_BLOBS_TOKEN` secret to this value.
+
+> **Runtime-managed tokens**
+>
+> When the site runs inside Netlify’s infrastructure it now detects and prefers the platform-managed blob token that Netlify injects at request time. You can safely remove a manually configured `NETLIFY_BLOBS_TOKEN` once uploads succeed—diagnostics will show the token source as “runtime-managed.” Keep a personal access token handy for local testing or emergency overrides, but production no longer needs the secret in the environment variables.
+
+## 3. Link the token to the correct site ID
+1. From the Netlify dashboard, open the **Sites** tab and select the site that hosts this app.
+2. On the site overview page, scroll to **Site information** and expand it to reveal the **API ID** (UUID). This is Netlify’s canonical Site ID.
+3. Copy the API ID and set it as `NETLIFY_BLOBS_SITE_ID` in your environment. Using the UUID skips the slug lookup path that requires additional REST permissions.
+4. If you can only supply a site slug, keep `NETLIFY_BLOBS_SITE_SLUG` populated *and* ensure the token from step 2 has access to the Sites API. Otherwise, the app cannot resolve the slug before writing to blobs.
+
+## 4. Validate optional URL overrides (if any)
+1. Only follow this step if you have provided `NETLIFY_BLOBS_EDGE_URL`, `NETLIFY_BLOBS_API_URL`, or similar overrides.
+2. In the blob store view from step 1, check the **Region** value. Netlify uses different base URLs per region.
+3. Compare the region to the override values you have set. Confirm the hostnames point to the same region as your store. In particular, do **not** send writes to `https://netlify-blobs.netlify.app`; that domain serves cached reads only. The app now ignores both the cached and uncached edge overrides for write calls, rewrites any API override that targets the read-only host back to `https://api.netlify.com/api/v1/blobs`, and logs a warning—but you should still remove the overrides to avoid future regressions. For upload operations, rely on `NETLIFY_BLOBS_API_URL=https://api.netlify.com/api/v1/blobs` (the default applied automatically when missing) and remove the edge overrides unless Netlify support instructs otherwise.
+4. After adjusting overrides, redeploy the environment so the updated settings apply.
+
+## 5. Ensure Next.js API routes deploy on Netlify
+1. Confirm the repository includes a `netlify.toml` with the Next.js build command, `.next` publish directory, and the `@netlify/plugin-nextjs` entry. Without the plugin the App Router API endpoints (such as `/api/diagnostics`) are never compiled into Netlify Functions, yielding 404 responses in production.
+2. After pushing configuration changes, trigger a fresh deploy and inspect the build logs. Look for `Framework detected: Next.js` and the Netlify adapter’s summary of generated API routes. If the log instead reports a static build, delete any conflicting build settings in the Netlify UI and redeploy.
+3. When the deploy finishes, run `netlify functions:list` or open the deploy summary and confirm functions like `api_diagnostics` exist. Their presence verifies Netlify can execute your in-app diagnostics suite.
+
+## 6. Confirm the deployment context in diagnostics
+1. Open the in-app **Diagnostics** page and run the full suite.
+2. In the log viewer, find the `***KEY NETFLIFY ITEMS***` block. It now repeats the store/token/site wiring and lists the detected deployment origin and URL so you can verify you are exercising the intended test release (for example, `https://dadsbot.netlify.app`).
+3. If the deployment origin or URL do not match the environment you expected, re-run the tests from the correct host before continuing troubleshooting.
+
+## After completing the checklist
+Redeploy the site (or trigger the failing tests again) to confirm blob uploads now succeed. If 405 errors persist, recheck the store name, token scope, and site ID for typographical errors, then contact Netlify support with the failing request ID shown in the diagnostics.

--- a/lib/blob.ts
+++ b/lib/blob.ts
@@ -1,4 +1,5 @@
-import { getStore, type Store } from '@netlify/blobs'
+import { getStore, setEnvironmentContext, type Store } from '@netlify/blobs'
+import type { GetStoreOptions } from '@netlify/blobs'
 import { flagFox } from './foxes'
 
 export type PutBlobOptions = {
@@ -27,7 +28,7 @@ type NetlifyContext = {
 type NetlifyConfig = {
   storeName: string
   siteId: string
-  token: string
+  token: string | null
   apiUrl?: string
   edgeUrl?: string
   uncachedEdgeUrl?: string
@@ -137,11 +138,16 @@ const memoryStore: Map<string, MemoryBlobRecord> = globalAny[GLOBAL_STORE_KEY]
 
 let netlifyConfig: NetlifyConfig | null | undefined
 let netlifyStore: Store | null | undefined
+let netlifyStoreConfigKey: string | null = null
 let netlifyWarningIssued = false
 let netlifyDiagnostics: BlobEnvDiagnostics | null | undefined
 let netlifySiteResolution: Promise<SiteResolution | null> | null = null
 let netlifySiteResolutionSlug: string | null = null
 let netlifySiteResolutionNotified = false
+let netlifyEdgeOverrideSuppressed = false
+let netlifyContextKey: string | null = null
+let netlifyEnvSanitizedKey: string | null = null
+let netlifyImplicitAttempted = false
 
 type SiteResolution = {
   slug: string
@@ -200,7 +206,7 @@ function looksLikeSiteId(value: string): boolean {
 async function resolveSiteId(config: NetlifyConfig): Promise<SiteResolution | null> {
   const slug = config.siteId.trim()
   if (!slug.length) return null
-  const token = config.token.trim()
+  const token = typeof config.token === 'string' ? config.token.trim() : ''
   if (!token.length) return null
   const base = (config.apiUrl || '').trim() || NETLIFY_API_BASE_URL
   const url = new URL(`/api/v1/sites/${encodeURIComponent(slug)}`, base)
@@ -263,6 +269,10 @@ async function ensureCanonicalSiteId(config: NetlifyConfig): Promise<NetlifyConf
       return config
     }
     return { ...config }
+  }
+
+  if (!config.token || !config.token.trim().length) {
+    return config
   }
 
   if (!netlifySiteResolution || netlifySiteResolutionSlug !== config.siteId) {
@@ -704,18 +714,19 @@ function readNetlifyConfig(): { config: NetlifyConfig | null; diagnostics: BlobE
   if (!diagnostics.siteId.present) diagnostics.missing.push('siteId')
   if (!diagnostics.token.present) diagnostics.missing.push('token')
 
-  const config: NetlifyConfig | null =
-    diagnostics.siteId.present && diagnostics.token.present
-      ? {
-          storeName: storePick?.value || storeName,
-          siteId: siteIdPick!.value,
-          token: tokenPick!.value,
-          apiUrl: apiPick?.value || undefined,
-          edgeUrl: edgePick?.value || undefined,
-          uncachedEdgeUrl: uncachedPick?.value || undefined,
-          consistency,
-        }
-      : null
+  const tokenValue = tokenPick?.value || null
+
+  const config: NetlifyConfig | null = diagnostics.siteId.present
+    ? {
+        storeName: storePick?.value || storeName,
+        siteId: siteIdPick!.value,
+        token: tokenValue,
+        apiUrl: apiPick?.value || undefined,
+        edgeUrl: edgePick?.value || undefined,
+        uncachedEdgeUrl: uncachedPick?.value || undefined,
+        consistency,
+      }
+    : null
 
   return { config, diagnostics }
 }
@@ -750,22 +761,277 @@ function getBlobEnvDiagnostics(): BlobEnvDiagnostics {
   return netlifyDiagnostics ?? defaultDiagnostics()
 }
 
+function shouldSuppressEdgeOverride(edgeUrl: string): boolean {
+  const trimmed = edgeUrl.trim()
+  if (!trimmed.length) return true
+  try {
+    const parsed = new URL(trimmed)
+    const hostname = parsed.hostname.toLowerCase()
+    if (hostname === 'netlify-blobs.netlify.app') {
+      return true
+    }
+    if (hostname.endsWith('.netlify.app') && hostname.startsWith('netlify-blobs')) {
+      return true
+    }
+  } catch {
+    if (/netlify-blobs\.netlify\.app/i.test(trimmed)) {
+      return true
+    }
+  }
+  return false
+}
+
+function noteEdgeOverrideSuppressed(
+  edgeUrl: string,
+  field: 'edgeUrl' | 'uncachedEdgeUrl' | 'apiUrl'
+) {
+  const fieldDiagnostics =
+    field === 'edgeUrl'
+      ? netlifyDiagnostics?.optional?.edgeUrl
+      : field === 'uncachedEdgeUrl'
+      ? netlifyDiagnostics?.optional?.uncachedEdgeUrl
+      : netlifyDiagnostics?.optional?.apiUrl
+
+  const selected = fieldDiagnostics?.selected
+  if (selected && fieldDiagnostics) {
+    const existingNote = selected.note ? `${selected.note}; ` : ''
+    fieldDiagnostics.selected = {
+      ...selected,
+      note: `${existingNote}suppressed for uploads`,
+    }
+  }
+
+  if (!netlifyEdgeOverrideSuppressed) {
+    netlifyEdgeOverrideSuppressed = true
+    flagFox({
+      id: 'theory-2-edge-override-suppressed',
+      theory: 2,
+      level: 'warn',
+      message:
+        'Netlify blob configuration provided a read-only host override; using the API host for uploads instead.',
+      details: { edgeUrl, field },
+    })
+  }
+}
+
+function sanitizeConfigForStore(config: NetlifyConfig): NetlifyConfig {
+  const sanitized: NetlifyConfig = { ...config }
+  let mutated = false
+
+  if (sanitized.edgeUrl && shouldSuppressEdgeOverride(sanitized.edgeUrl)) {
+    noteEdgeOverrideSuppressed(sanitized.edgeUrl, 'edgeUrl')
+    sanitized.edgeUrl = undefined
+    mutated = true
+  }
+
+  if (sanitized.uncachedEdgeUrl && shouldSuppressEdgeOverride(sanitized.uncachedEdgeUrl)) {
+    noteEdgeOverrideSuppressed(sanitized.uncachedEdgeUrl, 'uncachedEdgeUrl')
+    sanitized.uncachedEdgeUrl = undefined
+    mutated = true
+  }
+
+  const defaultApi = `${NETLIFY_API_BASE_URL}/api/v1/blobs`
+
+  if (sanitized.apiUrl) {
+    if (shouldSuppressEdgeOverride(sanitized.apiUrl)) {
+      noteEdgeOverrideSuppressed(sanitized.apiUrl, 'apiUrl')
+      sanitized.apiUrl = defaultApi
+      mutated = true
+    }
+  } else {
+    sanitized.apiUrl = defaultApi
+    mutated = true
+  }
+
+  return mutated ? sanitized : config
+}
+
+function isNetlifyRuntime(): boolean {
+  const netlifyFlag = (process.env.NETLIFY || '').toLowerCase()
+  if (netlifyFlag === 'true') return true
+  if ((process.env.NETLIFY_LOCAL || '').toLowerCase() === 'true') return true
+  if ((process.env.NETLIFY_DEV || '').toLowerCase() === 'true') return true
+  if (process.env.DEPLOY_ID || process.env.NETLIFY_CONTEXT) return true
+  return false
+}
+
+function initializeImplicitNetlifyStore(config: NetlifyConfig): Store | null {
+  const storeName = config.storeName?.trim()
+  if (!storeName) return null
+  if (!isNetlifyRuntime()) return null
+
+  const options: GetStoreOptions = { name: storeName }
+
+  if (config.siteId) options.siteID = config.siteId
+  if (config.apiUrl) options.apiURL = config.apiUrl
+  if (config.edgeUrl) options.edgeURL = config.edgeUrl
+  if (config.uncachedEdgeUrl) options.uncachedEdgeURL = config.uncachedEdgeUrl
+  if (config.consistency) options.consistency = config.consistency
+
+  try {
+    const store = getStore(options)
+    if (netlifyDiagnostics) {
+      netlifyDiagnostics.usingContext = true
+      const keys = new Set(netlifyDiagnostics.contextKeys ?? [])
+      keys.add('token')
+      keys.add('siteID')
+      netlifyDiagnostics.contextKeys = Array.from(keys)
+      netlifyDiagnostics.token.present = true
+      netlifyDiagnostics.token.length = undefined
+      netlifyDiagnostics.token.selected = {
+        key: 'context.token',
+        source: 'context',
+        present: true,
+        valuePreview: 'runtime-managed',
+        note: 'Using Netlify-managed site token provided at runtime.',
+      }
+      netlifyDiagnostics.missing = netlifyDiagnostics.missing.filter((entry) => entry !== 'token')
+    }
+    flagFox({
+      id: 'theory-2-runtime-token',
+      theory: 2,
+      level: 'info',
+      message: 'Netlify runtime token detected; using managed credentials for blob uploads.',
+    })
+    return store
+  } catch (error) {
+    if (!netlifyImplicitAttempted) {
+      netlifyImplicitAttempted = true
+      console.warn('Failed to initialize Netlify blob store with runtime-managed credentials', error)
+    }
+    return null
+  }
+}
+
+function applySanitizedEnvironmentOverrides(config: NetlifyConfig) {
+  const beforeSnapshot = JSON.stringify({
+    api: config.apiUrl ?? null,
+    edge: config.edgeUrl ?? null,
+    uncached: config.uncachedEdgeUrl ?? null,
+    envEdge: process.env.NETLIFY_BLOBS_EDGE_URL ?? null,
+    envUncached: process.env.NETLIFY_BLOBS_UNCACHED_EDGE_URL ?? null,
+    envApi: process.env.NETLIFY_BLOBS_API_URL ?? null,
+  })
+
+  if (beforeSnapshot === netlifyEnvSanitizedKey) {
+    return
+  }
+
+  const edgeEnv = process.env.NETLIFY_BLOBS_EDGE_URL
+  if (edgeEnv && shouldSuppressEdgeOverride(edgeEnv)) {
+    delete process.env.NETLIFY_BLOBS_EDGE_URL
+  }
+
+  const uncachedEnv = process.env.NETLIFY_BLOBS_UNCACHED_EDGE_URL
+  if (uncachedEnv && shouldSuppressEdgeOverride(uncachedEnv)) {
+    delete process.env.NETLIFY_BLOBS_UNCACHED_EDGE_URL
+  }
+
+  const apiEnv = process.env.NETLIFY_BLOBS_API_URL
+  const desiredApi = config.apiUrl
+
+  if (desiredApi) {
+    if (apiEnv !== desiredApi) {
+      process.env.NETLIFY_BLOBS_API_URL = desiredApi
+    }
+  } else if (apiEnv && shouldSuppressEdgeOverride(apiEnv)) {
+    process.env.NETLIFY_BLOBS_API_URL = `${NETLIFY_API_BASE_URL}/api/v1/blobs`
+  }
+
+  const afterSnapshot = JSON.stringify({
+    api: config.apiUrl ?? null,
+    edge: config.edgeUrl ?? null,
+    uncached: config.uncachedEdgeUrl ?? null,
+    envEdge: process.env.NETLIFY_BLOBS_EDGE_URL ?? null,
+    envUncached: process.env.NETLIFY_BLOBS_UNCACHED_EDGE_URL ?? null,
+    envApi: process.env.NETLIFY_BLOBS_API_URL ?? null,
+  })
+
+  netlifyEnvSanitizedKey = afterSnapshot
+}
+
+function applySanitizedEnvironmentContext(config: NetlifyConfig) {
+  const context = parseNetlifyContext() ?? {}
+  const sanitizedContext: NetlifyContext = {
+    ...context,
+    siteID: config.siteId,
+  }
+
+  if (config.token && config.token.trim().length) {
+    sanitizedContext.token = config.token
+  }
+
+  if (config.apiUrl) {
+    sanitizedContext.apiURL = config.apiUrl
+  }
+
+  if (config.edgeUrl) {
+    sanitizedContext.edgeURL = config.edgeUrl
+  }
+
+  if (config.uncachedEdgeUrl) {
+    sanitizedContext.uncachedEdgeURL = config.uncachedEdgeUrl
+  }
+
+  const serialized = JSON.stringify(sanitizedContext)
+  if (serialized === netlifyContextKey) {
+    return
+  }
+
+  try {
+    setEnvironmentContext(sanitizedContext)
+    netlifyContextKey = serialized
+  } catch (error) {
+    console.warn('Failed to apply sanitized Netlify blobs context', error)
+  }
+}
+
+function buildStoreConfigKey(config: NetlifyConfig): string {
+  return JSON.stringify({
+    name: config.storeName,
+    siteId: config.siteId,
+    token: config.token,
+    apiUrl: config.apiUrl || null,
+    edgeUrl: config.edgeUrl || null,
+    uncachedEdgeUrl: config.uncachedEdgeUrl || null,
+    consistency: config.consistency || null,
+  })
+}
+
 async function getNetlifyStore(): Promise<Store | null> {
   const baseConfig = getNetlifyConfig()
   if (!baseConfig) return null
 
-  const config = await ensureCanonicalSiteId(baseConfig)
+  const canonicalConfig =
+    baseConfig.token && baseConfig.token.trim().length
+      ? await ensureCanonicalSiteId(baseConfig)
+      : baseConfig
+  const config = sanitizeConfigForStore(canonicalConfig)
+  const configKey = buildStoreConfigKey(config)
 
-  if (!netlifyStore) {
-    netlifyStore = getStore({
-      name: config.storeName,
-      siteID: config.siteId,
-      token: config.token,
-      apiURL: config.apiUrl,
-      edgeURL: config.edgeUrl,
-      uncachedEdgeURL: config.uncachedEdgeUrl,
-      consistency: config.consistency,
-    })
+  if (!netlifyStore || netlifyStoreConfigKey !== configKey) {
+    applySanitizedEnvironmentOverrides(config)
+    if (config.token && config.token.trim().length) {
+      applySanitizedEnvironmentContext(config)
+      netlifyStore = getStore({
+        name: config.storeName,
+        siteID: config.siteId,
+        token: config.token,
+        apiURL: config.apiUrl,
+        edgeURL: config.edgeUrl,
+        uncachedEdgeURL: config.uncachedEdgeUrl,
+        consistency: config.consistency,
+      })
+      netlifyStoreConfigKey = configKey
+    } else {
+      const implicitStore = initializeImplicitNetlifyStore(config)
+      if (implicitStore) {
+        netlifyStore = implicitStore
+        netlifyStoreConfigKey = configKey
+      } else {
+        netlifyStore = null
+      }
+    }
   }
 
   return netlifyStore

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+  framework = "next"
+
+[functions]
+  node_bundler = "esbuild"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: { serverActions: { allowedOrigins: ['*'] } },
+  experimental: {
+    appDir: true,
+    serverActions: { allowedOrigins: ['*'] },
+  },
   output: 'standalone',
 }
 module.exports = nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "zustand": "4.5.4"
       },
       "devDependencies": {
+        "@netlify/plugin-nextjs": "^5.13.5",
         "@playwright/test": "1.46.1",
         "@types/node": "20.11.30",
         "@types/react": "18.3.3",
@@ -718,6 +719,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs": {
+      "version": "5.13.5",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.13.5.tgz",
+      "integrity": "sha512-zuP4sqckaeJ8rtiNYwoOpQnEb/8E4Ewf+FJDxts2s6gfgmXGuk4W5ViKZtITWWjuzxqbxG+p4t20PXltIyeJBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@netlify/runtime-utils": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "zustand": "4.5.4"
   },
   "devDependencies": {
+    "@netlify/plugin-nextjs": "^5.13.5",
     "@playwright/test": "1.46.1",
     "@types/node": "20.11.30",
     "@types/react": "18.3.3",

--- a/tests/blob.test.ts
+++ b/tests/blob.test.ts
@@ -5,6 +5,11 @@ afterEach(() => {
   delete process.env.NETLIFY_BLOBS_TOKEN
   delete process.env.NETLIFY_BLOBS_STORE
   delete process.env.NETLIFY_BLOBS_CONTEXT
+  delete process.env.NETLIFY
+  delete process.env.NETLIFY_LOCAL
+  delete process.env.NETLIFY_DEV
+  delete process.env.NETLIFY_CONTEXT
+  delete process.env.DEPLOY_ID
   vi.resetModules()
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
@@ -26,7 +31,10 @@ describe('putBlobFromBuffer', () => {
     }
 
     const getStoreSpy = vi.fn(() => storeMock)
-    vi.doMock('@netlify/blobs', () => ({ getStore: getStoreSpy }))
+    vi.doMock('@netlify/blobs', () => ({
+      getStore: getStoreSpy,
+      setEnvironmentContext: vi.fn(),
+    }))
 
     const { putBlobFromBuffer } = await import('../lib/blob')
     const result = await putBlobFromBuffer('path/file.txt', Buffer.from('hello'), 'text/plain')
@@ -45,8 +53,43 @@ describe('putBlobFromBuffer', () => {
     expect(result.downloadUrl).toBe(result.url)
   })
 
+  it('uses the Netlify runtime token when environment credentials are absent', async () => {
+    process.env.NETLIFY = 'true'
+    process.env.NETLIFY_BLOBS_SITE_ID = '12345678-1234-1234-1234-1234567890ab'
+    process.env.NETLIFY_BLOBS_STORE = 'store-name'
+
+    const setSpy = vi.fn(async () => ({}))
+    const storeMock = {
+      set: setSpy,
+      list: vi.fn(async () => ({ blobs: [] })),
+      getMetadata: vi.fn(async () => null),
+      delete: vi.fn(async () => {}),
+      getWithMetadata: vi.fn(async () => null),
+    }
+
+    const getStoreSpy = vi.fn(() => storeMock)
+    vi.doMock('@netlify/blobs', () => ({
+      getStore: getStoreSpy,
+      setEnvironmentContext: vi.fn(),
+    }))
+
+    const { putBlobFromBuffer } = await import('../lib/blob')
+    await putBlobFromBuffer('path/file.txt', Buffer.from('runtime'), 'text/plain')
+
+    expect(getStoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'store-name' }),
+    )
+    const callArg = getStoreSpy.mock.calls[0][0] as Record<string, unknown>
+    expect(callArg).not.toHaveProperty('token')
+    expect(callArg).toHaveProperty('siteID', '12345678-1234-1234-1234-1234567890ab')
+    expect(setSpy).toHaveBeenCalled()
+  })
+
   it('falls back to a data URL when storage is not configured', async () => {
-    vi.doMock('@netlify/blobs', () => ({ getStore: vi.fn() }))
+    vi.doMock('@netlify/blobs', () => ({
+      getStore: vi.fn(),
+      setEnvironmentContext: vi.fn(),
+    }))
     const { putBlobFromBuffer } = await import('../lib/blob')
     const result = await putBlobFromBuffer('path/file.txt', Buffer.from('hi'), 'text/plain')
 
@@ -76,7 +119,10 @@ it('resolves a site slug to the canonical Netlify site ID', async () => {
   }))
   vi.stubGlobal('fetch', fetchSpy)
 
-  vi.doMock('@netlify/blobs', () => ({ getStore: getStoreSpy }))
+  vi.doMock('@netlify/blobs', () => ({
+    getStore: getStoreSpy,
+    setEnvironmentContext: vi.fn(),
+  }))
 
   const { putBlobFromBuffer } = await import('../lib/blob')
   await putBlobFromBuffer('path/file.txt', Buffer.from('hello'), 'text/plain')
@@ -93,7 +139,10 @@ it('resolves a site slug to the canonical Netlify site ID', async () => {
 
 describe('listBlobs', () => {
   it('returns fallback entries when storage is not configured', async () => {
-    vi.doMock('@netlify/blobs', () => ({ getStore: vi.fn() }))
+    vi.doMock('@netlify/blobs', () => ({
+      getStore: vi.fn(),
+      setEnvironmentContext: vi.fn(),
+    }))
     const { putBlobFromBuffer, listBlobs, clearFallbackBlobs } = await import('../lib/blob')
     clearFallbackBlobs()
 


### PR DESCRIPTION
## Summary
- allow blob configuration to proceed without an explicit token and bootstrap the Netlify store with runtime-managed credentials when available
- update diagnostics and environment sanitization to avoid overwriting managed tokens while still enforcing API host rewrites
- document the new runtime-token flow and extend unit tests to cover the implicit credential path
- ensure the implicit Netlify runtime path provides the site ID to blob stores and reflects runtime-managed credentials in diagnostics

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e5374a7e3c832a9bc6991df3648649