### PR TITLE
Fix broken build + improve first-run onboarding UX

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2261,6 +2261,87 @@ input[type="checkbox"] {
   gap: 12px;
 }
 
+.recorder-welcome {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.recorder-welcome__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.recorder-welcome__lede {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.recorder-welcome__steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.recorder-welcome__steps li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--ink);
+}
+
+.recorder-welcome__step-num {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(251, 191, 36, 0.18);
+  border: 1px solid var(--accent);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.recorder-welcome__guest {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(74, 222, 128, 0.08);
+  border: 1px solid rgba(74, 222, 128, 0.25);
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.recorder-welcome__guest strong {
+  color: var(--ink);
+}
+
+.recorder-welcome__guest button {
+  flex-shrink: 0;
+}
+
 .floating-voice-recorder__content {
   display: flex;
   flex-direction: column;

--- a/app/history/history-view.tsx
+++ b/app/history/history-view.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ACTIVE_USER_HANDLE_STORAGE_KEY,
   normalizeHandle,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2175,12 +2175,9 @@ export function Home({ userHandle }: { userHandle?: string }) {
     await finalizeNow()
   }, [finalizeNow, pushLog, requestManualStop])
 
-  useEffect(() => {
-    if (!sessionId) return
-    if (hasStarted) return
-    if (startupError || fatalError) return
-    startSession().catch(() => {})
-  }, [fatalError, hasStarted, sessionId, startSession, startupError])
+  // Note: we intentionally do NOT auto-start the interview. The session only
+  // begins when the user taps the hero button (see handleHeroPress). A real
+  // user gesture is required for microphone access and audio playback.
 
   useEffect(() => {
     if (machineState === 'readyToContinue' && hasStarted) {
@@ -2220,12 +2217,25 @@ export function Home({ userHandle }: { userHandle?: string }) {
 
   const handleHeroPress = useCallback(() => {
     if (startupError || fatalError) return
+    if (!hasStarted && machineState === 'idle') {
+      // Explicit user gesture is required before we can request microphone
+      // access and play the intro audio — browsers block autoplay otherwise.
+      startSession().catch(() => {})
+      return
+    }
     if (machineState === 'recording') {
       requestManualStop()
     } else if (machineState === 'playing') {
       recorderRef.current?.skipPlayback()
     }
-  }, [fatalError, machineState, requestManualStop, startupError])
+  }, [fatalError, hasStarted, machineState, requestManualStop, startSession, startupError])
+
+  const handleNameYourself = useCallback(() => {
+    setIsAccountMenuOpen(true)
+    setIsAddingNewUser(true)
+    setNewUserError(null)
+    setHandleInput('')
+  }, [])
 
   const visual = STATE_VISUALS[machineState] ?? STATE_VISUALS.idle
   const _isInitialState = !hasStarted && machineState === 'idle'
@@ -2263,7 +2273,7 @@ export function Home({ userHandle }: { userHandle?: string }) {
       return 'Session halted—review Diagnostics for details.'
     }
     if (!hasStarted) {
-      return 'Let me welcome you first—I’ll begin automatically.'
+      return 'Tap the circle when you’re ready—I’ll welcome you and ask the first question.'
     }
     if (finishRequested) {
       return 'Wrapping up your session.'
@@ -2368,6 +2378,8 @@ export function Home({ userHandle }: { userHandle?: string }) {
       showSkipButton,
       statusHint,
       diagnosticsHref,
+      accountHandle: displayHandle,
+      onNameYourself: handleNameYourself,
     }
   }, [
     sessionId, machineState, turn, hasStarted, finishRequested, audioLevel,
@@ -2375,6 +2387,7 @@ export function Home({ userHandle }: { userHandle?: string }) {
     handleHeroPress, requestFinish, requestManualStop, manualStopRequested,
     visual, heroAriaLabel, heroIcon, heroBadge, heroTitle, heroDescription,
     heroDisabled, statusMessage, showSkipButton, statusHint, diagnosticsHref,
+    displayHandle, handleNameYourself,
   ])
 
   return (
@@ -2422,7 +2435,7 @@ export function Home({ userHandle }: { userHandle?: string }) {
             >
               <span className="account-switcher__label">Account</span>
               <span className="account-switcher__value">
-                {normalizedHandle ? `@${normalizedHandle}` : 'Default'}
+                {normalizedHandle ? `@${normalizedHandle}` : 'Guest'}
               </span>
               <span
                 className={`account-switcher__chevron${
@@ -2440,7 +2453,7 @@ export function Home({ userHandle }: { userHandle?: string }) {
                     role="menuitem"
                     onClick={handleClearSelection}
                   >
-                    Default account
+                    Continue as guest
                   </button>
                 ) : null}
                 {availableHandles.map((handle) => (

--- a/components/floating-voice-recorder.tsx
+++ b/components/floating-voice-recorder.tsx
@@ -45,6 +45,10 @@ interface FloatingVoiceRecorderProps {
   statusHint: string | null
   diagnosticsHref: string
 
+  // Onboarding / first-run
+  accountHandle: string | null
+  onNameYourself: () => void
+
   // Handlers
   onStartAgain: () => void
 }
@@ -76,13 +80,52 @@ export function FloatingVoiceRecorder({
   showSkipButton,
   statusHint,
   diagnosticsHref,
+  accountHandle,
+  onNameYourself,
   onStartAgain,
 }: FloatingVoiceRecorderProps) {
   const isSessionActive = hasStarted && (machineState !== 'idle' || finishRequested)
+  const showWelcome = !hasStarted && !startupError && !fatalError && !finishRequested
 
   return (
     <div className="floating-voice-recorder">
       <div className="floating-voice-recorder__container">
+        {showWelcome ? (
+          <div className="recorder-welcome">
+            <h2 className="recorder-welcome__title">
+              {accountHandle ? `Welcome back, @${accountHandle}` : 'Capture a memory, one question at a time'}
+            </h2>
+            <p className="recorder-welcome__lede">
+              DadsBot is a warm, voice-first biographer. Tap the circle below and it
+              will ask a question, then listen as you answer—no typing required.
+            </p>
+            <ol className="recorder-welcome__steps">
+              <li>
+                <span className="recorder-welcome__step-num">1</span>
+                Tap the circle to begin (we&apos;ll ask for the microphone once).
+              </li>
+              <li>
+                <span className="recorder-welcome__step-num">2</span>
+                Listen to the question, then just start talking.
+              </li>
+              <li>
+                <span className="recorder-welcome__step-num">3</span>
+                Tap when you&apos;re done, or say you&apos;re finished to save and email a recap.
+              </li>
+            </ol>
+            {!accountHandle ? (
+              <div className="recorder-welcome__guest">
+                <span>
+                  You&apos;re recording as a <strong>guest</strong>. Add a name so your
+                  stories are saved and remembered next time.
+                </span>
+                <button type="button" className="btn-secondary" onClick={onNameYourself}>
+                  Add your name
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
         <div className="floating-voice-recorder__content">
           <button
             type="button"

--- a/lib/history-fixer.ts
+++ b/lib/history-fixer.ts
@@ -79,8 +79,8 @@ function buildArtifactPatchFromStored(stored?: StoredSession | null): Record<str
   return patch
 }
 
-function buildTurnsFromStored(session: StoredSession): SummarizableTurn[] {
-  const turns: SummarizableTurn[] = []
+function buildTurnsFromStored(session: StoredSession): Array<{ role: 'user' | 'assistant'; text: string }> {
+  const turns: Array<{ role: 'user' | 'assistant'; text: string }> = []
   for (const turn of session.turns) {
     const transcript = typeof turn.transcript === 'string' ? turn.transcript.trim() : ''
     if (transcript) {
@@ -201,13 +201,13 @@ export async function runHistoryFixer(options: { handle?: string | null } = {}):
   const deletedStorageSessions: string[] = []
 
   for (const session of sorted) {
-    let digestTurns = session.turns
+    let digestTurns: Array<{ role: 'user' | 'assistant'; text: string }> = session.turns
       .map((turn) => {
         const text = typeof turn.text === 'string' ? turn.text.trim() : ''
         if (!text) return null
         return { role: turn.role, text }
       })
-      .filter((turn): turn is SummarizableTurn => Boolean(turn))
+      .filter((turn): turn is { role: 'user' | 'assistant'; text: string } => turn !== null)
 
     let hasUserTurns = hasMeaningfulUserTurn(digestTurns)
     if (!digestTurns.length || !hasUserTurns) {
@@ -219,7 +219,7 @@ export async function runHistoryFixer(options: { handle?: string | null } = {}):
             session.stored = storedFallback
           }
         } catch {
-          storedFallback = null
+          storedFallback = undefined
         }
       }
       if (storedFallback) {
@@ -298,7 +298,7 @@ export async function runHistoryFixer(options: { handle?: string | null } = {}):
 
     if (session.origin === 'supabase' && session.stored) {
       const patch: {
-        status?: string
+        status?: 'error' | 'in_progress' | 'completed' | 'emailed'
         totalTurns?: number
         durationMs?: number
         artifacts?: Record<string, string>


### PR DESCRIPTION
## Why

Two things were keeping DadsBot from working end-to-end:

1. **The production build was broken.** Recent auto-pushed commits introduced TypeScript errors that fail `next build`, so **every Vercel deploy since then has failed** and the live app has been frozen on stale code. `main` is affected too — this PR is what unblocks deploys.
2. **The interview auto-started on page load**, which (a) dropped brand-new visitors straight into a recording with no explanation, and (b) triggered microphone access and TTS audio playback with **no user gesture** — which browsers commonly block, so the very first turn often failed silently.

## What changed

### Build fix (the critical unblock)
- Add the missing `useMemo` import in `app/history/history-view.tsx`.
- Fix a silently-failing `.filter` type guard, a `null` vs `undefined` assignment, and a `status` union mismatch in `lib/history-fixer.ts`.
- `npm run build`, `tsc --noEmit`, and `next lint` all pass clean.

### First-run / onboarding UX
- **Start is now an explicit user action.** Tapping the hero ring starts the session (a real gesture → mic + audio playback allowed). Removed the silent auto-start.
- **New welcome panel** for the not-started state: explains what DadsBot is and how it works in three steps, plus a prompt for guests to add a name so their stories are saved.
- Relabeled the anonymous account from the misleading **"Default"** to **"Guest"** and clarified the account-menu copy.

## Verification
- `tsc --noEmit` ✅ · `next lint` ✅ · `next build` ✅
- Dev server boots (HTTP 200); the welcome panel renders (`Welcome back, @grandpa` for known handles, the guest variant otherwise).
- A full visual screenshot wasn't possible in this environment (no browser binary / blocked download), and the live recording flow needs the Vercel-configured secrets to exercise.

## Notes / follow-ups (not in this PR)
From the broader review, the next-highest-leverage items are: a setup/health gate so missing config surfaces up front instead of failing mid-interview, consolidating the dual Supabase-table + blob stores (and the aggressive 24h auto-delete), removing the dead duplicate `/history` `/settings` `/diagnostics` routes, and collapsing the stacked error banners. Happy to take these on next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHFZoXRuo1th4DRafBWNwA)_